### PR TITLE
Optimize for "small" maps (capacity fits in 32 bits)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,9 @@ quickcheck = "0.3.1"
 fnv = "1.0"
 lazy_static = "0.2"
 
+[features]
+# for testing only, of course
+test_low_transition_point = []
+
 [profile.bench]
 debug = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@ use std::borrow::Borrow;
 
 use std::cmp::max;
 use std::fmt;
+use std::mem;
 use std::mem::{swap, replace};
+use std::marker::PhantomData;
 
 use util::{second, ptr_eq, enumerate};
 
@@ -38,16 +40,70 @@ impl PartialEq for HashValue {
     }
 }
 
-type PosType = usize;
+/// A possibly truncated hash value.
+///
+#[derive(Debug)]
+struct ShortHash<Sz>(usize, PhantomData<Sz>);
 
-macro_rules! debug {
-    ($fmt:expr) => { };
-    ($fmt:expr, $($t:tt)*) => { };
+impl<Sz> ShortHash<Sz> {
+    /// Pretend this is a full HashValue, which
+    /// is completely ok w.r.t determining bucket index
+    ///
+    /// - Sz = u32: 32-bit hash is enough to select bucket index
+    /// - Sz = u64: hash is not truncated
+    fn into_hash(self) -> HashValue {
+        HashValue(self.0)
+    }
 }
 
+impl<Sz> Copy for ShortHash<Sz> { }
+impl<Sz> Clone for ShortHash<Sz> {
+    #[inline]
+    fn clone(&self) -> Self { *self }
+}
+
+impl<Sz> PartialEq for ShortHash<Sz> {
+    #[inline]
+    fn eq(&self, rhs: &Self) -> bool {
+        self.0 == rhs.0
+    }
+}
+
+// Compare ShortHash == HashValue by truncating appropriately
+// if applicable before the comparison
+impl<Sz> PartialEq<HashValue> for ShortHash<Sz> where Sz: Size {
+    #[inline]
+    fn eq(&self, rhs: &HashValue) -> bool {
+        if Sz::is_64_bit() {
+            self.0 == rhs.0
+        } else {
+            lo32(self.0 as u64) == lo32(rhs.0 as u64)
+        }
+    }
+}
+impl<Sz> From<ShortHash<Sz>> for HashValue {
+    fn from(x: ShortHash<Sz>) -> Self { HashValue(x.0) }
+}
+
+/// `Pos` is stored in the `indices` array and it points to the index of an
+/// `Entry` in self.entries.
+///
+/// Pos can be interpreted either as a 64-bit index, or as a 32-bit index and
+/// a 32-bit hash.
+///
+/// Storing the truncated hash next to the index saves loading the hash from the
+/// entry, increasing the cache efficiency.
+///
+/// Note that the lower 32 bits of the hash is enough to compute desired
+/// position and probe distance in a hash map with less than 2**32 buckets.
+///
+/// The OrderMap will simply query its **current raw capacity** to see what its
+/// current size class is, and dispatch to the 32-bit or 64-bit lookup code as
+/// appropriate. Only the growth code needs some extra logic to handle the
+/// transition from one class to another
 #[derive(Copy)]
 struct Pos {
-    index: PosType,
+    index: u64,
 }
 
 impl Clone for Pos {
@@ -58,20 +114,86 @@ impl Clone for Pos {
 impl fmt::Debug for Pos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.pos() {
-            Some(i) => write!(f, "Pos({})", i),
+            Some(i) => write!(f, "Pos({} / {:x})", i, self.index),
             None => write!(f, "Pos(None)"),
         }
     }
 }
 
 impl Pos {
-    #[inline(always)]
-    fn new(i: usize) -> Self { Pos { index: i as PosType } }
-    #[inline(always)]
-    fn none() -> Self { Pos { index: PosType::max_value() } }
-    #[inline(always)]
+    #[inline]
+    fn none() -> Self { Pos { index: !0 } }
+
+    #[inline]
+    fn is_none(&self) -> bool { self.index == !0 }
+
+    #[inline]
     fn pos(&self) -> Option<usize> {
-        if self.index == PosType::max_value() { None } else { Some(self.index as usize) }
+        if self.index == !0 { None } else { Some(lo32(self.index as u64)) }
+    }
+
+    #[inline]
+    fn with_hash<Sz>(i: usize, hash: HashValue) -> Self
+        where Sz: Size
+    {
+        if Sz::is_64_bit() {
+            Pos {
+                index: i as u64,
+            }
+        } else {
+            Pos {
+                index: (i | (lo32(hash.0 as u64) << 32)) as u64
+            }
+        }
+    }
+
+    #[inline]
+    fn resolve<Sz>(&self) -> Option<(usize, ShortHashProxy<Sz>)>
+        where Sz: Size
+    {
+        if Sz::is_64_bit() {
+            if !self.is_none() {
+                Some((self.index as usize, ShortHashProxy::new(0)))
+            } else {
+                None
+            }
+        } else {
+            if !self.is_none() {
+                let (i, hash) = split_lo_hi(self.index);
+                Some((i as usize, ShortHashProxy::new(hash as usize)))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[inline]
+fn lo32(x: u64) -> usize { (x & 0xFFFF_FFFF) as usize }
+
+// split into low, hi parts
+#[inline]
+fn split_lo_hi(x: u64) -> (u32, u32) { (x as u32, (x >> 32) as u32) }
+
+// Possibly contains the truncated hash value for an entry, depending on
+// the size class.
+struct ShortHashProxy<Sz>(usize, PhantomData<Sz>);
+
+impl<Sz> ShortHashProxy<Sz>
+    where Sz: Size
+{
+    fn new(x: usize) -> Self {
+        ShortHashProxy(x, PhantomData)
+    }
+
+    /// Get the hash from either `self` or from a lookup into `entries`,
+    /// depending on `Sz`.
+    fn get_short_hash<K, V>(&self, entries: &[Entry<K, V>], index: usize) -> ShortHash<Sz> {
+        if Sz::is_64_bit() {
+            ShortHash(entries[index].hash.0, PhantomData)
+        } else {
+            ShortHash(self.0, PhantomData)
+        }
     }
 }
 
@@ -85,7 +207,9 @@ impl Pos {
 #[derive(Clone)]
 pub struct OrderMap<K, V, S = RandomState> {
     mask: usize,
+    /// indices are the buckets. indices.len() == raw capacity
     indices: Vec<Pos>,
+    /// entries is a dense vec of entries in their order. entries.len() == len
     entries: Vec<Entry<K, V>>,
     hash_builder: S,
 }
@@ -195,17 +319,30 @@ impl<K, V, S> OrderMap<K, V, S>
             }
         } else {
             let raw = to_raw_capacity(n);
-            let power = max(raw.next_power_of_two(), 8);
+            let raw_cap = max(raw.next_power_of_two(), 8);
             OrderMap {
-                mask: power.wrapping_sub(1),
-                indices: vec![Pos::none(); power],
-                entries: Vec::with_capacity(usable_capacity(power)),
+                mask: raw_cap.wrapping_sub(1),
+                indices: vec![Pos::none(); raw_cap],
+                entries: Vec::with_capacity(usable_capacity(raw_cap)),
                 hash_builder: hash_builder,
             }
         }
     }
 
     pub fn len(&self) -> usize { self.entries.len() }
+
+    // Return whether we need 32 or 64 bits to specify a bucket or entry index
+    #[cfg(not(feature = "test_low_transition_point"))]
+    fn size_class_is_64bit(&self) -> bool {
+        usize::max_value() > u32::max_value() as usize &&
+            self.raw_capacity() >= u32::max_value() as usize
+    }
+
+    // for testing
+    #[cfg(feature = "test_low_transition_point")]
+    fn size_class_is_64bit(&self) -> bool {
+        self.raw_capacity() >= 64
+    }
 
     #[inline(always)]
     fn raw_capacity(&self) -> usize {
@@ -217,6 +354,50 @@ impl<K, V, S> OrderMap<K, V, S>
     }
 }
 
+/// Trait for the "size class". Either u32 or u64 depending on the index
+/// size needed to address an entry's indes in self.entries.
+trait Size {
+    fn is_64_bit() -> bool;
+    fn is_same_size<T>() -> bool
+        where Self: Sized
+    {
+        mem::size_of::<T>() == mem::size_of::<Self>()
+    }
+}
+
+impl Size for u32 {
+    #[inline]
+    fn is_64_bit() -> bool { false }
+}
+
+impl Size for u64 {
+    #[inline]
+    fn is_64_bit() -> bool { true }
+}
+
+/// Call self.method(args) with `::<u32>` or `::<u64>` depending on `self`
+/// size class.
+///
+/// The u32 or u64 is *prepended* to the type parameter list!
+macro_rules! dispatch_32_vs_64 {
+    ($self_:ident . $method:ident::<$($t:ty),*>($($arg:expr),*)) => {
+        if $self_.size_class_is_64bit() {
+            $self_.$method::<u64, $($t),*>($($arg),*)
+        } else {
+            $self_.$method::<u32, $($t),*>($($arg),*)
+        }
+    };
+    ($self_:ident . $method:ident ($($arg:expr),*)) => {
+        if $self_.size_class_is_64bit() {
+            $self_.$method::<u64>($($arg),*)
+        } else {
+            $self_.$method::<u32>($($arg),*)
+        }
+    };
+}
+
+
+
 impl<K, V, S> OrderMap<K, V, S>
     where K: Eq + Hash,
           S: BuildHasher,
@@ -227,25 +408,29 @@ impl<K, V, S> OrderMap<K, V, S>
             *pos = Pos::none();
         }
     }
+
     // First phase: Look for the preferred location for key.
     //
     // We will know if `key` is already in the map, before we need to insert it.
     // When we insert they key, it might be that we need to continue displacing
     // entries (robin hood hashing), in which case Inserted::RobinHood is returned
-    fn insert_phase_1(&mut self, key: K, value: V) -> Inserted {
+    fn insert_phase_1<Sz>(&mut self, key: K, value: V) -> Inserted
+        where Sz: Size
+    {
         let hash = hash_elem_using(&self.hash_builder, &key);
         let mut probe = desired_pos(self.mask, hash);
         let mut dist = 0;
         let insert_kind;
         debug_assert!(self.len() < self.raw_capacity());
         probe_loop!(probe < self.indices.len(), {
-            if let Some(i) = self.indices[probe].pos() {
+            if let Some((i, hash_proxy)) = self.indices[probe].resolve::<Sz>() {
+                let entry_hash = hash_proxy.get_short_hash(&self.entries, i);
                 // if existing element probed less than us, swap
-                let their_dist = probe_distance(self.mask, self.entries[i].hash, probe);
+                let their_dist = probe_distance(self.mask, entry_hash.into_hash(), probe);
                 if their_dist < dist {
                     // robin hood: steal the spot if it's better for us
                     let index = self.entries.len();
-                    let mut pos = Pos::new(index);
+                    let mut pos = Pos::with_hash::<Sz>(index, hash);
                     swap(&mut pos, &mut self.indices[probe]);
                     insert_kind = Inserted::RobinHood {
                         probe: probe,
@@ -253,13 +438,13 @@ impl<K, V, S> OrderMap<K, V, S>
                         dist: their_dist,
                     };
                     break;
-                } else if self.entries[i].hash == hash && self.entries[i].key == key {
+                } else if entry_hash == hash && self.entries[i].key == key {
                     return Inserted::AlreadyExists;
                 }
             } else {
                 // empty bucket, insert here
                 let index = self.entries.len();
-                self.indices[probe] = Pos::new(index);
+                self.indices[probe] = Pos::with_hash::<Sz>(index, hash);
                 insert_kind = Inserted::Done;
                 break;
             }
@@ -269,11 +454,14 @@ impl<K, V, S> OrderMap<K, V, S>
         insert_kind
     }
 
-    fn insert_phase_2(&mut self, mut probe: usize, mut old_pos: Pos, mut dist: usize) {
+    fn insert_phase_2<Sz>(&mut self, mut probe: usize, mut old_pos: Pos, mut dist: usize)
+        where Sz: Size
+    {
         probe_loop!(probe < self.indices.len(), {
-            if let Some(i) = self.indices[probe].pos() {
+            if let Some((i, hash_proxy)) = self.indices[probe].resolve::<Sz>() {
+                let entry_hash = hash_proxy.get_short_hash(&self.entries, i);
                 // if existing element probed less than us, swap
-                let their_dist = probe_distance(self.mask, self.entries[i].hash, probe);
+                let their_dist = probe_distance(self.mask, entry_hash.into_hash(), probe);
                 if their_dist < dist {
                     swap(&mut old_pos, &mut self.indices[probe]);
                     dist = their_dist;
@@ -288,14 +476,17 @@ impl<K, V, S> OrderMap<K, V, S>
 
     fn first_allocation(&mut self) {
         debug_assert_eq!(self.len(), 0);
-        let power = 8usize;
-        self.mask = power.wrapping_sub(1);
-        self.indices = vec![Pos::none(); power];
-        self.entries = Vec::with_capacity(usable_capacity(power));
+        let raw_cap = 8usize;
+        self.mask = raw_cap.wrapping_sub(1);
+        self.indices = vec![Pos::none(); raw_cap];
+        self.entries = Vec::with_capacity(usable_capacity(raw_cap));
     }
 
     #[inline(never)]
-    fn double_capacity(&mut self) {
+    // `Sz` is *current* Size class, before grow
+    fn double_capacity<Sz>(&mut self)
+        where Sz: Size
+    {
         debug_assert!(self.raw_capacity() == 0 || self.len() > 0);
         if self.raw_capacity() == 0 {
             return self.first_allocation();
@@ -314,19 +505,17 @@ impl<K, V, S> OrderMap<K, V, S>
 
         // visit the entries in an order where we can simply reinsert them
         // into self.indices without any bucket stealing.
-        let new_power = self.indices.len() * 2;
-        let old_indices = replace(&mut self.indices, vec![Pos::none(); new_power]);
-        self.mask = new_power.wrapping_sub(1);
-        for pos in &old_indices[first_ideal..] {
-            if let Some(i) = pos.pos() {
-                self.reinsert_entry_in_order(i);
-            }
+        let new_raw_cap = self.indices.len() * 2;
+        let old_indices = replace(&mut self.indices, vec![Pos::none(); new_raw_cap]);
+        self.mask = new_raw_cap.wrapping_sub(1);
+
+        // `Sz` is the old size class, and either u32 or u64 is the new
+        for &pos in &old_indices[first_ideal..] {
+            dispatch_32_vs_64!(self.reinsert_entry_in_order::<Sz>(pos));
         }
 
-        for pos in &old_indices[..first_ideal] {
-            if let Some(i) = pos.pos() {
-                self.reinsert_entry_in_order(i);
-            }
+        for &pos in &old_indices[..first_ideal] {
+            dispatch_32_vs_64!(self.reinsert_entry_in_order::<Sz>(pos));
         }
         let more = self.capacity() - self.len();
         self.entries.reserve_exact(more);
@@ -334,32 +523,56 @@ impl<K, V, S> OrderMap<K, V, S>
 
     // write to self.indices
     // read from self.entries at `index`
-    fn reinsert_entry_in_order(&mut self, index: usize) {
-        // find first empty bucket and insert there
-        let mut probe = desired_pos(self.mask, self.entries[index].hash);
-        probe_loop!(probe < self.indices.len(), {
-            if let Some(_) = self.indices[probe].pos() {
-                /* nothing */
+    //
+    // reinserting rewrites all `Pos` entries anyway. This handles transitioning
+    // from u32 to u64 size class automatically, just by using the two type
+    // parameters.
+    fn reinsert_entry_in_order<SzNew, SzOld>(&mut self, pos: Pos)
+        where SzNew: Size,
+              SzOld: Size,
+    {
+        if let Some((i, hash_proxy)) = pos.resolve::<SzOld>() {
+            // only if the size class is conserved can we use the short hash
+            let entry_hash = if SzOld::is_same_size::<SzNew>() {
+                hash_proxy.get_short_hash(&self.entries, i).into_hash()
             } else {
-                // empty bucket, insert here
-                self.indices[probe] = Pos::new(index);
-                return;
-            }
-        });
+                self.entries[i].hash
+            };
+            // find first empty bucket and insert there
+            let mut probe = desired_pos(self.mask, entry_hash);
+            probe_loop!(probe < self.indices.len(), {
+                if let Some(_) = self.indices[probe].resolve::<SzNew>() {
+                    /* nothing */
+                } else {
+                    // empty bucket, insert here
+                    self.indices[probe] = Pos::with_hash::<SzNew>(i, entry_hash);
+                    return;
+                }
+            });
+        }
     }
 
     fn reserve_one(&mut self) {
         if self.len() == self.capacity() {
-            self.double_capacity();
+            dispatch_32_vs_64!(self.double_capacity());
         }
     }
 
     pub fn insert(&mut self, key: K, value: V) {
         self.reserve_one();
-        match self.insert_phase_1(key, value) {
-            Inserted::AlreadyExists | Inserted::Done => { }
-            Inserted::RobinHood { probe, old_pos, dist } => {
-                self.insert_phase_2(probe, old_pos, dist);
+        if self.size_class_is_64bit() {
+            match self.insert_phase_1::<u64>(key, value) {
+                Inserted::AlreadyExists | Inserted::Done => { }
+                Inserted::RobinHood { probe, old_pos, dist } => {
+                    self.insert_phase_2::<u64>(probe, old_pos, dist);
+                }
+            }
+        } else {
+            match self.insert_phase_1::<u32>(key, value) {
+                Inserted::AlreadyExists | Inserted::Done => { }
+                Inserted::RobinHood { probe, old_pos, dist } => {
+                    self.insert_phase_2::<u32>(probe, old_pos, dist);
+                }
             }
         }
 
@@ -431,9 +644,7 @@ impl<K, V, S> OrderMap<K, V, S>
     {
         if self.len() == 0 { return None; }
         let h = hash_elem_using(&self.hash_builder, &key);
-        self.find_using(h, move |entry| {
-            h == entry.hash && *entry.key.borrow() == *key
-        })
+        self.find_using(h, move |entry| { *entry.key.borrow() == *key })
     }
 
     /// Remove the key-value pair equivalent to `key` and return
@@ -497,16 +708,23 @@ impl<K, V, S> OrderMap<K, V, S> {
     fn find_using<F>(&self, hash: HashValue, key_eq: F) -> Option<(usize, usize)>
         where F: Fn(&Entry<K, V>) -> bool,
     {
+        dispatch_32_vs_64!(self.find_using_impl::<_>(hash, key_eq))
+    }
+
+    fn find_using_impl<Sz, F>(&self, hash: HashValue, key_eq: F) -> Option<(usize, usize)>
+        where F: Fn(&Entry<K, V>) -> bool,
+              Sz: Size,
+    {
         debug_assert!(self.len() > 0);
         let mut probe = desired_pos(self.mask, hash);
         let mut dist = 0;
         probe_loop!(probe < self.indices.len(), {
-            if let Some(i) = self.indices[probe].pos() {
-                let entry = &self.entries[i];
-                if dist > probe_distance(self.mask, entry.hash, probe) {
+            if let Some((i, hash_proxy)) = self.indices[probe].resolve::<Sz>() {
+                let entry_hash = hash_proxy.get_short_hash(&self.entries, i);
+                if dist > probe_distance(self.mask, entry_hash.into_hash(), probe) {
                     // give up when probe distance is too long
                     return None;
-                } else if key_eq(entry) {
+                } else if entry_hash == hash && key_eq(&self.entries[i]) {
                     return Some((probe, i));
                 }
             } else {
@@ -522,7 +740,12 @@ impl<K, V, S> OrderMap<K, V, S> {
         self.find_using(entry.hash, move |other_ent| ptr_eq(entry, other_ent))
     }
 
-    fn remove_found(&mut self, probe: usize, found: usize) -> Option<(K, V)>
+    fn remove_found(&mut self, probe: usize, found: usize) -> Option<(K, V)> {
+        dispatch_32_vs_64!(self.remove_found_impl(probe, found))
+    }
+
+    fn remove_found_impl<Sz>(&mut self, probe: usize, found: usize) -> Option<(K, V)>
+        where Sz: Size
     {
         // index `probe` and entry `found` is to be removed
         // use swap_remove, but then we need to update the index that points
@@ -536,10 +759,10 @@ impl<K, V, S> OrderMap<K, V, S> {
             // examine new element in `found` and find it in indices
             let mut probe = desired_pos(self.mask, entry.hash);
             probe_loop!(probe < self.indices.len(), {
-                if let Some(i) = self.indices[probe].pos() {
+                if let Some((i, _)) = self.indices[probe].resolve::<Sz>() {
                     if i >= self.entries.len() {
                         // found it
-                        self.indices[probe] = Pos::new(found);
+                        self.indices[probe] = Pos::with_hash::<Sz>(found, entry.hash);
                         break;
                     }
                 }
@@ -551,9 +774,10 @@ impl<K, V, S> OrderMap<K, V, S> {
             let mut last_probe = probe;
             let mut probe = probe + 1;
             probe_loop!(probe < self.indices.len(), {
-                if let Some(i) = self.indices[probe].pos() {
-                    if probe_distance(self.mask, self.entries[i].hash, probe) > 0 {
-                        self.indices[last_probe] = Pos::new(i);
+                if let Some((i, hash_proxy)) = self.indices[probe].resolve::<Sz>() {
+                    let entry_hash = hash_proxy.get_short_hash(&self.entries, i);
+                    if probe_distance(self.mask, entry_hash.into_hash(), probe) > 0 {
+                        self.indices[last_probe] = self.indices[probe];
                         self.indices[probe] = Pos::none();
                     } else {
                         break;
@@ -569,7 +793,6 @@ impl<K, V, S> OrderMap<K, V, S> {
     }
 
 }
-
 
 use std::slice::Iter as SliceIter;
 use std::slice::IterMut as SliceIterMut;
@@ -866,9 +1089,16 @@ mod tests {
         }
 
         println!("{:?}", map);
-        map.double_capacity();
+        for &elt in &insert {
+            map.insert(elt * 10, elt);
+        }
+        for &elt in &insert {
+            map.insert(elt * 100, elt);
+        }
+        for (i, &elt) in insert.iter().cycle().enumerate().take(100) {
+            map.insert(elt * 100 + i as i32, elt);
+        }
         println!("{:?}", map);
-
         for &elt in &not_present {
             assert!(map.get(&elt).is_none());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,11 +522,10 @@ impl<K, V, S> OrderMap<K, V, S>
     }
 
     // write to self.indices
-    // read from self.entries at `index`
+    // read from self.entries at `pos`
     //
     // reinserting rewrites all `Pos` entries anyway. This handles transitioning
-    // from u32 to u64 size class automatically, just by using the two type
-    // parameters.
+    // from u32 to u64 size class if needed by using the two type parameters.
     fn reinsert_entry_in_order<SzNew, SzOld>(&mut self, pos: Pos)
         where SzNew: Size,
               SzOld: Size,


### PR DESCRIPTION
I think the case hash maps being smaller than 2<sup>32</sup> elements is pretty common.