### PR TITLE
Adds a OrderMap::drain() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -105,6 +105,18 @@ quickcheck! {
         map.capacity() >= cap
     }
 
+    fn drain(insert: Vec<u8>) -> bool {
+        let mut map = OrderMap::new();
+        for &key in &insert {
+            map.insert(key, ());
+        }
+        let mut clone = map.clone();
+        let drained = clone.drain(..);
+        for (key, _) in drained {
+            map.remove(&key);
+        }
+        map.is_empty()
+    }
 }
 
 use Op::*;


### PR DESCRIPTION
Problem:
Porting some code that used HashMap's drain to OrderMap revealed a small
API gap.

Solution:
Added a drain method, mostly mirroring what std::collections::HashMap
offers except returning a standard Vec instead of a Drain.

drain() provides an efficient way to remove all values without shrinking
the capacity of the original OrderMap.

Validation:
Added unit tests and ported an existing HashMap::drain() user to
OrderMap::drain