### PR TITLE
Implement Extend<(&K, &V)> for Copy types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1517,6 +1517,16 @@ impl<K, V, S> Extend<(K, V)> for OrderMap<K, V, S>
     }
 }
 
+impl<'a, K, V, S> Extend<(&'a K, &'a V)> for OrderMap<K, V, S>
+    where K: Hash + Eq + Copy,
+          V: Copy,
+          S: BuildHasher,
+{
+    fn extend<I: IntoIterator<Item=(&'a K, &'a V)>>(&mut self, iterable: I) {
+        self.extend(iterable.into_iter().map(|(&key, &value)| (key, value)));
+    }
+}
+
 impl<K, V, S> Default for OrderMap<K, V, S>
     where S: BuildHasher + Default,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1765,4 +1765,12 @@ mod tests {
         assert_ne!(map_a, map_c);
         assert_ne!(map_c, map_a);
     }
+
+    #[test]
+    fn extend() {
+        let mut map = OrderMap::new();
+        map.extend(vec![(&1, &2), (&3, &4)]);
+        map.extend(vec![(5, 6)]);
+        assert_eq!(map.into_iter().collect::<Vec<_>>(), vec![(1, 2), (3, 4), (5, 6)]);
+    }
 }


### PR DESCRIPTION
This matches `hash_extend_copy` feature stabilized in Rust 1.4.0 introduced by https://github.com/rust-lang/rust/pull/28094. Note that this may affect type inference.