### PR TITLE
Link the README.md file in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ documentation = "https://docs.rs/ordermap/"
 repository = "https://github.com/bluss/ordermap"
 license = "Apache-2.0/MIT"
 description = "A hash table with consistent order and fast iteration."
+readme = "README.md"
 
 [lib]
 bench = false


### PR DESCRIPTION
This way, crates.io and docs.rs will render it.