### PR TITLE
Add OrderSet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ mod util;
 mod equivalent;
 mod mutable_keys;
 
+pub mod set;
+
 use std::hash::Hash;
 use std::hash::BuildHasher;
 use std::hash::Hasher;
@@ -28,6 +30,7 @@ use std::marker::PhantomData;
 use util::{third, ptrdistance, enumerate};
 pub use equivalent::Equivalent;
 pub use mutable_keys::MutableKeys;
+pub use set::OrderSet;
 
 fn hash_elem_using<B: BuildHasher, K: ?Sized + Hash>(build: &B, k: &K) -> HashValue {
     let mut h = build.build_hasher();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1195,6 +1195,8 @@ macro_rules! iterator_methods {
         fn collect<C>(self) -> C
             where C: FromIterator<Self::Item>
         {
+            // NB: forwarding this directly to standard iterators will
+            // allow it to leverage unstable traits like `TrustedLen`.
             self.iter.map($map_elt).collect()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! [`OrderMap`]: struct.OrderMap.html
 
+#[macro_use]
 mod macros;
 #[cfg(feature = "serde-1")]
 mod serde;
@@ -1165,42 +1166,6 @@ impl<K, V, S> OrderMap<K, V, S> {
 use std::slice::Iter as SliceIter;
 use std::slice::IterMut as SliceIterMut;
 use std::vec::IntoIter as VecIntoIter;
-
-// generate all the Iterator methods by just forwarding to the underlying
-// self.iter and mapping its element.
-macro_rules! iterator_methods {
-    // $map_elt is the mapping function from the underlying iterator's element
-    // same mapping function for both options and iterators
-    ($map_elt:expr) => {
-        fn next(&mut self) -> Option<Self::Item> {
-            self.iter.next().map($map_elt)
-        }
-
-        fn size_hint(&self) -> (usize, Option<usize>) {
-            self.iter.size_hint()
-        }
-
-        fn count(self) -> usize {
-            self.iter.len()
-        }
-
-        fn nth(&mut self, n: usize) -> Option<Self::Item> {
-            self.iter.nth(n).map($map_elt)
-        }
-
-        fn last(mut self) -> Option<Self::Item> {
-            self.next_back()
-        }
-
-        fn collect<C>(self) -> C
-            where C: FromIterator<Self::Item>
-        {
-            // NB: forwarding this directly to standard iterators will
-            // allow it to leverage unstable traits like `TrustedLen`.
-            self.iter.map($map_elt).collect()
-        }
-    }
-}
 
 pub struct Keys<'a, K: 'a, V: 'a> {
     iter: SliceIter<'a, Bucket<K, V>>,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -59,10 +59,13 @@ macro_rules! ordermap {
 /// # }
 /// ```
 macro_rules! orderset {
+    (@single $($x:tt)*) => (());
+    (@count $($rest:expr),*) => (<[()]>::len(&[$(orderset!(@single $rest)),*]));
+
     ($($value:expr,)+) => { orderset!($($value),+) };
     ($($value:expr),*) => {
         {
-            let _cap = ordermap!(@count $($value),*);
+            let _cap = orderset!(@count $($value),*);
             let mut _set = $crate::OrderSet::with_capacity(_cap);
             $(
                 _set.insert($value);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,3 +36,38 @@ macro_rules! ordermap {
         }
     };
 }
+
+#[macro_export]
+/// Create an `OrderSet` from a list of values
+///
+/// ## Example
+///
+/// ```
+/// #[macro_use] extern crate ordermap;
+/// # fn main() {
+///
+/// let set = orderset!{
+///     "a",
+///     "b",
+/// };
+/// assert!(set.contains("a"));
+/// assert!(set.contains("b"));
+/// assert!(!set.contains("c"));
+///
+/// // "a" is the first value
+/// assert_eq!(set.iter().next(), Some(&"a"));
+/// # }
+/// ```
+macro_rules! orderset {
+    ($($value:expr,)+) => { orderset!($($value),+) };
+    ($($value:expr),*) => {
+        {
+            let _cap = ordermap!(@count $($value),*);
+            let mut _set = $crate::OrderSet::with_capacity(_cap);
+            $(
+                _set.insert($value);
+            )*
+            _set
+        }
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -74,3 +74,39 @@ macro_rules! orderset {
         }
     };
 }
+
+// generate all the Iterator methods by just forwarding to the underlying
+// self.iter and mapping its element.
+macro_rules! iterator_methods {
+    // $map_elt is the mapping function from the underlying iterator's element
+    // same mapping function for both options and iterators
+    ($map_elt:expr) => {
+        fn next(&mut self) -> Option<Self::Item> {
+            self.iter.next().map($map_elt)
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            self.iter.size_hint()
+        }
+
+        fn count(self) -> usize {
+            self.iter.len()
+        }
+
+        fn nth(&mut self, n: usize) -> Option<Self::Item> {
+            self.iter.nth(n).map($map_elt)
+        }
+
+        fn last(mut self) -> Option<Self::Item> {
+            self.next_back()
+        }
+
+        fn collect<C>(self) -> C
+            where C: FromIterator<Self::Item>
+        {
+            // NB: forwarding this directly to standard iterators will
+            // allow it to leverage unstable traits like `TrustedLen`.
+            self.iter.map($map_elt).collect()
+        }
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -43,7 +43,7 @@ impl<'de, K, V, S> Visitor<'de> for OrderMapVisitor<K, V, S>
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
         where A: MapAccess<'de>
     {
-        let mut values = OrderMap::with_capacity_and_hasher(map.size_hint().unwrap_or(0), Default::default());
+        let mut values = OrderMap::with_capacity_and_hasher(map.size_hint().unwrap_or(0), S::default());
 
         while let Some((key, value)) = try!(map.next_entry()) {
             values.insert(key, value);
@@ -100,7 +100,7 @@ impl<'de, T, S> Visitor<'de> for OrderSetVisitor<T, S>
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
         where A: SeqAccess<'de>
     {
-        let mut values = OrderSet::with_capacity_and_hasher(seq.size_hint().unwrap_or(0), Default::default());
+        let mut values = OrderSet::with_capacity_and_hasher(seq.size_hint().unwrap_or(0), S::default());
 
         while let Some(value) = try!(seq.next_element()) {
             values.insert(value);

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,8 +1,8 @@
 
 extern crate serde;
 
-use self::serde::ser::{Serialize, Serializer, SerializeMap};
-use self::serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
+use self::serde::ser::{Serialize, Serializer, SerializeMap, SerializeSeq};
+use self::serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 
 use std::fmt::{self, Formatter};
 use std::hash::{BuildHasher, Hash};
@@ -63,5 +63,61 @@ impl<'de, K, V, S> Deserialize<'de> for OrderMap<K, V, S>
         where D: Deserializer<'de>
     {
         deserializer.deserialize_map(OrderMapVisitor(PhantomData))
+    }
+}
+
+
+use OrderSet;
+
+/// Requires crate feature `"serde-1"`
+impl<T, S> Serialize for OrderSet<T, S>
+    where T: Serialize + Hash + Eq,
+          S: BuildHasher
+{
+    fn serialize<Se>(&self, serializer: Se) -> Result<Se::Ok, Se::Error>
+        where Se: Serializer
+    {
+        let mut set_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        for value in self {
+            try!(set_serializer.serialize_element(value));
+        }
+        set_serializer.end()
+    }
+}
+
+struct OrderSetVisitor<T, S>(PhantomData<(T, S)>);
+
+impl<'de, T, S> Visitor<'de> for OrderSetVisitor<T, S>
+    where T: Deserialize<'de> + Eq + Hash,
+          S: Default + BuildHasher
+{
+    type Value = OrderSet<T, S>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "a set")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where A: SeqAccess<'de>
+    {
+        let mut values = OrderSet::with_capacity_and_hasher(seq.size_hint().unwrap_or(0), Default::default());
+
+        while let Some(value) = try!(seq.next_element()) {
+            values.insert(value);
+        }
+
+        Ok(values)
+    }
+}
+
+/// Requires crate feature `"serde-1"`
+impl<'de, T, S> Deserialize<'de> for OrderSet<T, S>
+    where T: Deserialize<'de> + Eq + Hash,
+          S: Default + BuildHasher
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        deserializer.deserialize_seq(OrderSetVisitor(PhantomData))
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -27,7 +27,9 @@ type Bucket<T> = super::Bucket<T, ()>;
 /// insertion and removal calls on the set. The order does not depend on the
 /// values or the hash function at all.
 ///
-/// All iterators traverse the set in *the order*.
+/// All iterators traverse the set *in order*.  Set operation iterators like
+/// `union` produce a concatenated order, as do their matching "bitwise"
+/// operators.  See their documentation for specifics.
 ///
 /// # Indices
 ///
@@ -161,6 +163,8 @@ impl<T, S> OrderSet<T, S>
     }
 
     /// Return an iterator over the values that are in `self` but not `other`.
+    ///
+    /// Values are produced in the same order that they appear in `self`.
     pub fn difference<'a, S2>(&'a self, other: &'a OrderSet<T, S2>) -> Difference<'a, T, S2>
         where S2: BuildHasher
     {
@@ -172,6 +176,9 @@ impl<T, S> OrderSet<T, S>
 
     /// Return an iterator over the values that are in `self` or `other`,
     /// but not in both.
+    ///
+    /// Values from `self` are produced in their original order, followed by
+    /// values from `other` in their original order.
     pub fn symmetric_difference<'a, S2>(&'a self, other: &'a OrderSet<T, S2>)
         -> SymmetricDifference<'a, T, S, S2>
         where S2: BuildHasher
@@ -182,6 +189,8 @@ impl<T, S> OrderSet<T, S>
     }
 
     /// Return an iterator over the values that are in both `self` and `other`.
+    ///
+    /// Values are produced in the same order that they appear in `self`.
     pub fn intersection<'a, S2>(&'a self, other: &'a OrderSet<T, S2>) -> Intersection<'a, T, S2>
         where S2: BuildHasher
     {
@@ -192,6 +201,9 @@ impl<T, S> OrderSet<T, S>
     }
 
     /// Return an iterator over all values that are in `self` or `other`.
+    ///
+    /// Values from `self` are produced in their original order, followed by
+    /// values that are unique to `other` in their original order.
     pub fn union<'a, S2>(&'a self, other: &'a OrderSet<T, S2>) -> Union<'a, T, S>
         where S2: BuildHasher
     {
@@ -753,6 +765,9 @@ impl<'a, 'b, T, S1, S2> BitAnd<&'b OrderSet<T, S2>> for &'a OrderSet<T, S1>
 {
     type Output = OrderSet<T, S1>;
 
+    /// Returns the set intersection, cloned into a new set.
+    ///
+    /// Values are collected in the same order that they appear in `self`.
     fn bitand(self, other: &'b OrderSet<T, S2>) -> Self::Output {
         self.intersection(other).cloned().collect()
     }
@@ -765,6 +780,10 @@ impl<'a, 'b, T, S1, S2> BitOr<&'b OrderSet<T, S2>> for &'a OrderSet<T, S1>
 {
     type Output = OrderSet<T, S1>;
 
+    /// Returns the set union, cloned into a new set.
+    ///
+    /// Values from `self` are collected in their original order, followed by
+    /// values that are unique to `other` in their original order.
     fn bitor(self, other: &'b OrderSet<T, S2>) -> Self::Output {
         self.union(other).cloned().collect()
     }
@@ -777,6 +796,10 @@ impl<'a, 'b, T, S1, S2> BitXor<&'b OrderSet<T, S2>> for &'a OrderSet<T, S1>
 {
     type Output = OrderSet<T, S1>;
 
+    /// Returns the set symmetric-difference, cloned into a new set.
+    ///
+    /// Values from `self` are collected in their original order, followed by
+    /// values from `other` in their original order.
     fn bitxor(self, other: &'b OrderSet<T, S2>) -> Self::Output {
         self.symmetric_difference(other).cloned().collect()
     }
@@ -789,6 +812,9 @@ impl<'a, 'b, T, S1, S2> Sub<&'b OrderSet<T, S2>> for &'a OrderSet<T, S1>
 {
     type Output = OrderSet<T, S1>;
 
+    /// Returns the set difference, cloned into a new set.
+    ///
+    /// Values are collected in the same order that they appear in `self`.
     fn sub(self, other: &'b OrderSet<T, S2>) -> Self::Output {
         self.difference(other).cloned().collect()
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,0 +1,723 @@
+//! A hash set implemented as an `OrderMap` where the value is `()`.
+
+use std::cmp::Ordering;
+use std::collections::hash_map::RandomState;
+use std::fmt;
+use std::iter::FromIterator;
+use std::hash::{Hash, BuildHasher};
+use std::mem::replace;
+use std::ops::RangeFull;
+
+use super::{OrderMap, Equivalent};
+
+/// A hash set where the iteration order of the values is independent of their
+/// hash values.
+///
+/// The interface is closely compatible with the standard `HashSet`, but also
+/// has additional features.
+///
+/// # Order
+///
+/// The values have a consistent order that is determined by the sequence of
+/// insertion and removal calls on the set. The order does not depend on the
+/// values or the hash function at all.
+///
+/// All iterators traverse the set in *the order*.
+///
+/// # Indices
+///
+/// The values are indexed in a compact range without holes in the range
+/// `0..self.len()`. For example, the method `.get_full` looks up the index for
+/// a key, and the method `.get_index` looks up the value by index.
+///
+/// # Examples
+///
+/// ```
+/// use ordermap::OrderSet;
+///
+/// // Collects which letters appear in a sentence.
+/// let letters: OrderSet<_> = "a short treatise on fungi".chars().collect();
+/// 
+/// assert!(letters.contains(&'s'));
+/// assert!(letters.contains(&'t'));
+/// assert!(letters.contains(&'u'));
+/// assert!(!letters.contains(&'y'));
+/// ```
+#[derive(Clone)]
+pub struct OrderSet<T, S = RandomState> {
+    map: OrderMap<T, (), S>,
+}
+
+impl<T, S> fmt::Debug for OrderSet<T, S>
+    where T: fmt::Debug + Hash + Eq,
+          S: BuildHasher,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if cfg!(not(feature = "test_debug")) {
+            f.debug_set().entries(self.iter()).finish()
+        } else {
+            // Let the inner `OrderMap` print all of its details
+            f.debug_struct("OrderSet").field("map", &self.map).finish()
+        }
+    }
+}
+
+impl<T> OrderSet<T> {
+    /// Create a new set. (Does not allocate.)
+    pub fn new() -> Self {
+        OrderSet { map: OrderMap::new() }
+    }
+
+    /// Create a new set with capacity for `n` elements.
+    /// (Does not allocate if `n` is zero.)
+    ///
+    /// Computes in **O(n)** time.
+    pub fn with_capacity(n: usize) -> Self {
+        OrderSet { map: OrderMap::with_capacity(n) }
+    }
+}
+
+impl<T, S> OrderSet<T, S> {
+    /// Create a new set with capacity for `n` elements.
+    /// (Does not allocate if `n` is zero.)
+    ///
+    /// Computes in **O(n)** time.
+    pub fn with_capacity_and_hasher(n: usize, hash_builder: S) -> Self
+        where S: BuildHasher
+    {
+        OrderSet { map: OrderMap::with_capacity_and_hasher(n, hash_builder) }
+    }
+
+    /// Return the number of elements in the set.
+    ///
+    /// Computes in **O(1)** time.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Returns true if the set contains no elements.
+    ///
+    /// Computes in **O(1)** time.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Create a new set with `hash_builder`
+    pub fn with_hasher(hash_builder: S) -> Self
+        where S: BuildHasher
+    {
+        OrderSet { map: OrderMap::with_hasher(hash_builder) }
+    }
+
+    /// Return a reference to the set's `BuildHasher`.
+    pub fn hasher(&self) -> &S
+        where S: BuildHasher
+    {
+        self.map.hasher()
+    }
+
+    /// Computes in **O(1)** time.
+    pub fn capacity(&self) -> usize {
+        self.map.capacity()
+    }
+}
+
+impl<T, S> OrderSet<T, S>
+    where T: Hash + Eq,
+          S: BuildHasher,
+{
+    /// Remove all elements in the set, while preserving its capacity.
+    ///
+    /// Computes in **O(n)** time.
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+
+    /// FIXME Not implemented fully yet
+    pub fn reserve(&mut self, additional: usize) {
+        self.map.reserve(additional);
+    }
+
+    /// Insert the value into the map.
+    ///
+    /// If the value did already exist in the set, returns `false`;
+    /// otherwise, return `true`.
+    ///
+    /// Computes in **O(1)** time (amortized average).
+    pub fn insert(&mut self, value: T) -> bool {
+        self.map.insert(value, ()).is_none()
+    }
+
+    /// Return an iterator over the values of the set, in their order
+    pub fn iter(&self) -> Iter<T> {
+        Iter {
+            iter: self.map.keys()
+        }
+    }
+
+    /// Return `true` if an equivalent to `value` exists in the set.
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.contains_key(value)
+    }
+
+    /// Return a reference to the value stored in the set, if it is present,
+    /// else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&T>
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.get_full(value).map(|(_, x, &())| x)
+    }
+
+    /// Return item index and value
+    pub fn get_full<Q: ?Sized>(&self, value: &Q) -> Option<(usize, &T)>
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.get_full(value).map(|(i, x, &())| (i, x))
+    }
+
+    /// Adds a value to the set, replacing the existing value, if any, that is
+    /// equal to the given one. Returns the replaced value.
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn replace(&mut self, value: T) -> Option<T>
+    {
+        use super::Entry::*;
+
+        match self.map.entry(value) {
+            Vacant(e) => { e.insert(()); None },
+            Occupied(e) => {
+                // FIXME uses private fields!
+                let old_key = &mut e.map.entries[e.index].key;
+                Some(replace(old_key, e.key))
+            }
+        }
+    }
+
+    /// FIXME Same as .swap_remove
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
+        where Q: Hash + Equivalent<T>,
+    {
+        self.swap_remove(value)
+    }
+
+    /// Remove the value from the set, and return `true` if it was present.
+    ///
+    /// Like `Vec::swap_remove`, the value is removed by swapping it with the
+    /// last element of the set and popping it off. **This perturbs
+    /// the postion of what used to be the last element!**
+    ///
+    /// Return `false` if `value` was not in the set.
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn swap_remove<Q: ?Sized>(&mut self, value: &Q) -> bool
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.swap_remove(value).is_some()
+    }
+
+    /// FIXME Same as .swap_take
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+        where Q: Hash + Equivalent<T>,
+    {
+        self.swap_take(value)
+    }
+
+    /// Removes and returns the value in the set, if any, that is equal to the
+    /// given one.
+    ///
+    /// Like `Vec::swap_remove`, the value is removed by swapping it with the
+    /// last element of the set and popping it off. **This perturbs
+    /// the postion of what used to be the last element!**
+    ///
+    /// Return `None` if `value` was not in the set.
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn swap_take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.swap_remove_full(value).map(|(_, x, ())| x)
+    }
+
+    /// Remove the value from the set return it and the index it had.
+    ///
+    /// Like `Vec::swap_remove`, the value is removed by swapping it with the
+    /// last element of the set and popping it off. **This perturbs
+    /// the postion of what used to be the last element!**
+    ///
+    /// Return `None` if `value` was not in the set.
+    pub fn swap_remove_full<Q: ?Sized>(&mut self, value: &Q) -> Option<(usize, T)>
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.swap_remove_full(value).map(|(i, x, ())| (i, x))
+    }
+
+    /// Remove the last value
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn pop(&mut self) -> Option<T> {
+        self.map.pop().map(|(x, ())| x)
+    }
+
+    /// Scan through each value in the set and keep those where the
+    /// closure `keep` returns `true`.
+    ///
+    /// The order the elements are visited is not specified.
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn retain<F>(&mut self, mut keep: F)
+        where F: FnMut(&T) -> bool,
+    {
+        self.map.retain(move |x, &mut ()| keep(x))
+    }
+
+    /// Sort the values of the set and return a by value iterator of
+    /// the values with the result.
+    ///
+    /// The sort is stable.
+    pub fn sorted_by<F>(self, mut cmp: F) -> IntoIter<T>
+        where F: FnMut(&T, &T) -> Ordering
+    {
+        IntoIter {
+            iter: self.map.sorted_by(move |a, &(), b, &()| cmp(a, b)),
+        }
+    }
+
+    /// Clears the `OrderSet`, returning all values as a drain iterator.
+    /// Keeps the allocated memory for reuse.
+    pub fn drain(&mut self, range: RangeFull) -> Drain<T> {
+        Drain {
+            iter: self.map.drain(range),
+        }
+    }
+}
+
+impl<T, S> OrderSet<T, S> {
+    /// Get a value by index
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    ///
+    /// Computes in **O(1)** time.
+    pub fn get_index(&self, index: usize) -> Option<&T> {
+        self.map.get_index(index).map(|(x, &())| x)
+    }
+
+    /// Remove the key-value pair by index
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn swap_remove_index(&mut self, index: usize) -> Option<T> {
+        self.map.swap_remove_index(index).map(|(x, ())| x)
+    }
+}
+
+
+pub struct IntoIter<T> {
+    iter: super::IntoIter<T, ()>,
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|(x, ())| x)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.iter.len()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(x, ())| x)
+    }
+
+    fn last(mut self) -> Option<Self::Item> {
+        self.next_back()
+    }
+
+    fn collect<C>(self) -> C
+        where C: FromIterator<Self::Item>
+    {
+        self.iter.map(|(x, ())| x).collect()
+    }
+}
+
+impl<T> DoubleEndedIterator for IntoIter<T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|(x, ())| x)
+    }
+}
+
+impl<T> ExactSizeIterator for IntoIter<T> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+
+pub struct Iter<'a, T: 'a> {
+    iter: super::Keys<'a, T, ()>,
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.iter.len()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n)
+    }
+
+    fn last(mut self) -> Option<Self::Item> {
+        self.next_back()
+    }
+
+    fn collect<C>(self) -> C
+        where C: FromIterator<Self::Item>
+    {
+        self.iter.collect()
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+}
+
+impl<'a, T> ExactSizeIterator for Iter<'a, T> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+
+impl<'a, T, S> IntoIterator for &'a OrderSet<T, S>
+    where T: Hash + Eq,
+          S: BuildHasher,
+{
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T, S> IntoIterator for OrderSet<T, S>
+    where T: Hash + Eq,
+          S: BuildHasher,
+{
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            iter: self.map.into_iter(),
+        }
+    }
+}
+
+impl<T, S> FromIterator<T> for OrderSet<T, S>
+    where T: Hash + Eq,
+          S: BuildHasher + Default,
+{
+    fn from_iter<I: IntoIterator<Item=T>>(iterable: I) -> Self {
+        let iter = iterable.into_iter().map(|x| (x, ()));
+        OrderSet { map: OrderMap::from_iter(iter) }
+    }
+}
+
+impl<T, S> Extend<T> for OrderSet<T, S>
+    where T: Hash + Eq,
+          S: BuildHasher,
+{
+    fn extend<I: IntoIterator<Item=T>>(&mut self, iterable: I) {
+        let iter = iterable.into_iter().map(|x| (x, ()));
+        self.map.extend(iter);
+    }
+}
+
+impl<'a, T, S> Extend<&'a T> for OrderSet<T, S>
+    where T: Hash + Eq + Copy,
+          S: BuildHasher,
+{
+    fn extend<I: IntoIterator<Item=&'a T>>(&mut self, iterable: I) {
+        let iter = iterable.into_iter().map(|&x| x);
+        self.extend(iter);
+    }
+}
+
+
+impl<T, S> Default for OrderSet<T, S>
+    where S: BuildHasher + Default,
+{
+    fn default() -> Self {
+        OrderSet { map: OrderMap::default() }
+    }
+}
+
+impl<T, S1, S2> PartialEq<OrderSet<T, S2>> for OrderSet<T, S1>
+    where T: Hash + Eq,
+          S1: BuildHasher,
+          S2: BuildHasher
+{
+    fn eq(&self, other: &OrderSet<T, S2>) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+
+        self.iter().all(move |value| other.contains(value))
+    }
+}
+
+impl<T, S> Eq for OrderSet<T, S>
+    where T: Eq + Hash,
+          S: BuildHasher
+{
+}
+
+
+pub struct Drain<'a, T: 'a> {
+    iter: super::Drain<'a, T, ()>,
+}
+
+impl<'a, T> Iterator for Drain<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|(x, ())| x)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use util::enumerate;
+
+    #[test]
+    fn it_works() {
+        let mut set = OrderSet::new();
+        assert_eq!(set.is_empty(), true);
+        set.insert(1);
+        set.insert(1);
+        assert_eq!(set.len(), 1);
+        assert!(set.get(&1).is_some());
+        assert_eq!(set.is_empty(), false);
+    }
+
+    #[test]
+    fn new() {
+        let set = OrderSet::<String>::new();
+        println!("{:?}", set);
+        assert_eq!(set.capacity(), 0);
+        assert_eq!(set.len(), 0);
+        assert_eq!(set.is_empty(), true);
+    }
+
+    #[test]
+    fn insert() {
+        let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+        let not_present = [1, 3, 6, 9, 10];
+        let mut set = OrderSet::with_capacity(insert.len());
+
+        for (i, &elt) in enumerate(&insert) {
+            assert_eq!(set.len(), i);
+            set.insert(elt);
+            assert_eq!(set.len(), i + 1);
+            assert_eq!(set.get(&elt), Some(&elt));
+        }
+        println!("{:?}", set);
+
+        for &elt in &not_present {
+            assert!(set.get(&elt).is_none());
+        }
+    }
+
+    #[test]
+    fn insert_2() {
+        let mut set = OrderSet::with_capacity(16);
+
+        let mut values = vec![];
+        values.extend(0..16);
+        values.extend(128..267);
+
+        for &i in &values {
+            let old_set = set.clone();
+            set.insert(i);
+            for value in old_set.iter() {
+                if !set.get(value).is_some() {
+                    println!("old_set: {:?}", old_set);
+                    println!("set: {:?}", set);
+                    panic!("did not find {} in set", value);
+                }
+            }
+        }
+
+        for &i in &values {
+            assert!(set.get(&i).is_some(), "did not find {}", i);
+        }
+    }
+
+    #[test]
+    fn insert_order() {
+        let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
+        let mut set = OrderSet::new();
+
+        for &elt in &insert {
+            set.insert(elt);
+        }
+
+        assert_eq!(set.iter().count(), set.len());
+        assert_eq!(set.iter().count(), insert.len());
+        for (a, b) in insert.iter().zip(set.iter()) {
+            assert_eq!(a, b);
+        }
+        for (i, v) in (0..insert.len()).zip(set.iter()) {
+            assert_eq!(set.get_index(i).unwrap(), v);
+        }
+    }
+
+    #[test]
+    fn grow() {
+        let insert = [0, 4, 2, 12, 8, 7, 11];
+        let not_present = [1, 3, 6, 9, 10];
+        let mut set = OrderSet::with_capacity(insert.len());
+
+
+        for (i, &elt) in enumerate(&insert) {
+            assert_eq!(set.len(), i);
+            set.insert(elt);
+            assert_eq!(set.len(), i + 1);
+            assert_eq!(set.get(&elt), Some(&elt));
+        }
+
+        println!("{:?}", set);
+        for &elt in &insert {
+            set.insert(elt * 10);
+        }
+        for &elt in &insert {
+            set.insert(elt * 100);
+        }
+        for (i, &elt) in insert.iter().cycle().enumerate().take(100) {
+            set.insert(elt * 100 + i as i32);
+        }
+        println!("{:?}", set);
+        for &elt in &not_present {
+            assert!(set.get(&elt).is_none());
+        }
+    }
+
+    #[test]
+    fn remove() {
+        let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
+        let mut set = OrderSet::new();
+
+        for &elt in &insert {
+            set.insert(elt);
+        }
+
+        assert_eq!(set.iter().count(), set.len());
+        assert_eq!(set.iter().count(), insert.len());
+        for (a, b) in insert.iter().zip(set.iter()) {
+            assert_eq!(a, b);
+        }
+
+        let remove_fail = [99, 77];
+        let remove = [4, 12, 8, 7];
+
+        for &value in &remove_fail {
+            assert!(set.swap_remove_full(&value).is_none());
+        }
+        println!("{:?}", set);
+        for &value in &remove {
+        //println!("{:?}", set);
+            let index = set.get_full(&value).unwrap().0;
+            assert_eq!(set.swap_remove_full(&value), Some((index, value)));
+        }
+        println!("{:?}", set);
+
+        for value in &insert {
+            assert_eq!(set.get(value).is_some(), !remove.contains(value));
+        }
+        assert_eq!(set.len(), insert.len() - remove.len());
+        assert_eq!(set.iter().count(), insert.len() - remove.len());
+    }
+
+    #[test]
+    fn swap_remove_index() {
+        let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
+        let mut set = OrderSet::new();
+
+        for &elt in &insert {
+            set.insert(elt);
+        }
+
+        let mut vector = insert.to_vec();
+        let remove_sequence = &[3, 3, 10, 4, 5, 4, 3, 0, 1];
+
+        // check that the same swap remove sequence on vec and set
+        // have the same result.
+        for &rm in remove_sequence {
+            let out_vec = vector.swap_remove(rm);
+            let out_set = set.swap_remove_index(rm).unwrap();
+            assert_eq!(out_vec, out_set);
+        }
+        assert_eq!(vector.len(), set.len());
+        for (a, b) in vector.iter().zip(set.iter()) {
+            assert_eq!(a, b);
+        }
+    }
+
+    #[test]
+    fn partial_eq_and_eq() {
+        let mut set_a = OrderSet::new();
+        set_a.insert(1);
+        set_a.insert(2);
+        let mut set_b = set_a.clone();
+        assert_eq!(set_a, set_b);
+        set_b.remove(&1);
+        assert_ne!(set_a, set_b);
+
+        let set_c: OrderSet<_> = set_b.into_iter().collect();
+        assert_ne!(set_a, set_c);
+        assert_ne!(set_c, set_a);
+    }
+
+    #[test]
+    fn extend() {
+        let mut set = OrderSet::new();
+        set.extend(vec![&1, &2, &3, &4]);
+        set.extend(vec![5, 6]);
+        assert_eq!(set.into_iter().collect::<Vec<_>>(), vec![1, 2, 3, 4, 5, 6]);
+    }
+}

--- a/src/set.rs
+++ b/src/set.rs
@@ -386,33 +386,7 @@ pub struct IntoIter<T> {
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|entry| entry.key)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
-
-    fn count(self) -> usize {
-        self.iter.len()
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n).map(|entry| entry.key)
-    }
-
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
-    }
-
-    fn collect<C>(self) -> C
-        where C: FromIterator<Self::Item>
-    {
-        // NB: forwarding this directly to standard iterators will
-        // allow it to leverage unstable traits like `TrustedLen`.
-        self.iter.map(|entry| entry.key).collect()
-    }
+    iterator_methods!(|entry| entry.key);
 }
 
 impl<T> DoubleEndedIterator for IntoIter<T> {
@@ -435,33 +409,7 @@ pub struct Iter<'a, T: 'a> {
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|entry| &entry.key)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
-
-    fn count(self) -> usize {
-        self.iter.len()
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n).map(|entry| &entry.key)
-    }
-
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
-    }
-
-    fn collect<C>(self) -> C
-        where C: FromIterator<Self::Item>
-    {
-        // NB: forwarding this directly to standard iterators will
-        // allow it to leverage unstable traits like `TrustedLen`.
-        self.iter.map(|entry| &entry.key).collect()
-    }
+    iterator_methods!(|entry| &entry.key);
 }
 
 impl<'a, T> DoubleEndedIterator for Iter<'a, T> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -938,4 +938,86 @@ mod tests {
         set.extend(vec![5, 6]);
         assert_eq!(set.into_iter().collect::<Vec<_>>(), vec![1, 2, 3, 4, 5, 6]);
     }
+
+    #[test]
+    fn comparisons() {
+        let set_a: OrderSet<_> = (0..3).collect();
+        let set_b: OrderSet<_> = (3..6).collect();
+        let set_c: OrderSet<_> = (0..6).collect();
+        let set_d: OrderSet<_> = (3..9).collect();
+
+        assert!(!set_a.is_disjoint(&set_a));
+        assert!(set_a.is_subset(&set_a));
+        assert!(set_a.is_superset(&set_a));
+
+        assert!(set_a.is_disjoint(&set_b));
+        assert!(set_b.is_disjoint(&set_a));
+        assert!(!set_a.is_subset(&set_b));
+        assert!(!set_b.is_subset(&set_a));
+        assert!(!set_a.is_superset(&set_b));
+        assert!(!set_b.is_superset(&set_a));
+
+        assert!(!set_a.is_disjoint(&set_c));
+        assert!(!set_c.is_disjoint(&set_a));
+        assert!(set_a.is_subset(&set_c));
+        assert!(!set_c.is_subset(&set_a));
+        assert!(!set_a.is_superset(&set_c));
+        assert!(set_c.is_superset(&set_a));
+
+        assert!(!set_c.is_disjoint(&set_d));
+        assert!(!set_d.is_disjoint(&set_c));
+        assert!(!set_c.is_subset(&set_d));
+        assert!(!set_d.is_subset(&set_c));
+        assert!(!set_c.is_superset(&set_d));
+        assert!(!set_d.is_superset(&set_c));
+    }
+
+    #[test]
+    fn iter_comparisons() {
+        use std::iter::empty;
+
+        fn check<'a, I1, I2>(iter1: I1, iter2: I2)
+            where I1: Iterator<Item = &'a i32>,
+                  I2: Iterator<Item = i32>,
+        {
+            assert!(iter1.cloned().eq(iter2));
+        }
+
+        let set_a: OrderSet<_> = (0..3).collect();
+        let set_b: OrderSet<_> = (3..6).collect();
+        let set_c: OrderSet<_> = (0..6).collect();
+        let set_d: OrderSet<_> = (3..9).rev().collect();
+
+        check(set_a.difference(&set_a), empty());
+        check(set_a.symmetric_difference(&set_a), empty());
+        check(set_a.intersection(&set_a), 0..3);
+        check(set_a.union(&set_a), 0..3);
+
+        check(set_a.difference(&set_b), 0..3);
+        check(set_b.difference(&set_a), 3..6);
+        check(set_a.symmetric_difference(&set_b), 0..6);
+        check(set_b.symmetric_difference(&set_a), (3..6).chain(0..3));
+        check(set_a.intersection(&set_b), empty());
+        check(set_b.intersection(&set_a), empty());
+        check(set_a.union(&set_b), 0..6);
+        check(set_b.union(&set_a), (3..6).chain(0..3));
+
+        check(set_a.difference(&set_c), empty());
+        check(set_c.difference(&set_a), 3..6);
+        check(set_a.symmetric_difference(&set_c), 3..6);
+        check(set_c.symmetric_difference(&set_a), 3..6);
+        check(set_a.intersection(&set_c), 0..3);
+        check(set_c.intersection(&set_a), 0..3);
+        check(set_a.union(&set_c), 0..6);
+        check(set_c.union(&set_a), 0..6);
+
+        check(set_c.difference(&set_d), 0..3);
+        check(set_d.difference(&set_c), (6..9).rev());
+        check(set_c.symmetric_difference(&set_d), (0..3).chain((6..9).rev()));
+        check(set_d.symmetric_difference(&set_c), (6..9).rev().chain(0..3));
+        check(set_c.intersection(&set_d), 3..6);
+        check(set_d.intersection(&set_c), (3..6).rev());
+        check(set_c.union(&set_d), (0..6).chain((6..9).rev()));
+        check(set_d.union(&set_c), (3..9).rev().chain(0..3));
+    }
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -20,6 +20,18 @@ fn test_serde() {
 }
 
 #[test]
+fn test_serde_set() {
+    let set = orderset! { 1, 2, 3, 4 };
+    assert_tokens(&set,
+                  &[Token::Seq { len: Some(4) },
+                    Token::I32(1),
+                    Token::I32(2),
+                    Token::I32(3),
+                    Token::I32(4),
+                    Token::SeqEnd]);
+}
+
+#[test]
 fn test_serde_fnv_hasher() {
     let mut map: ::ordermap::OrderMap<i32, i32, ::fnv::FnvBuildHasher> = Default::default();
     map.insert(1, 2);
@@ -31,4 +43,17 @@ fn test_serde_fnv_hasher() {
                     Token::I32(3),
                     Token::I32(4),
                     Token::MapEnd]);
+}
+
+#[test]
+fn test_serde_map_fnv_hasher() {
+    let mut set: ::ordermap::OrderSet<i32, ::fnv::FnvBuildHasher> = Default::default();
+    set.extend(1..5);
+    assert_tokens(&set,
+                  &[Token::Seq { len: Some(4) },
+                    Token::I32(1),
+                    Token::I32(2),
+                    Token::I32(3),
+                    Token::I32(4),
+                    Token::SeqEnd]);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,3 +18,15 @@ fn test_sort() {
 }
 
 
+#[test]
+fn test_sort_set() {
+    let s = orderset! {
+        1,
+        7,
+        2,
+        3,
+    };
+
+    itertools::assert_equal(s.sorted_by(|v1, v2| v1.cmp(v2)),
+                            vec![1, 2, 3, 7]);
+}


### PR DESCRIPTION
An `OrderSet<T>` wraps an `OrderMap<T, ()>`, and also adds set-like
functionality: union, intersection, etc.

The type and all of its supporting iterators are defined in the public
`set` module, and `OrderSet` is re-exported at the crate root.  There is
also a new `orderset!` macro for construction.

Fixes #8.