### PR TITLE
Implement sorting in place for OrderMap, OrderSet

### DIFF
--- a/benches/faststring.rs
+++ b/benches/faststring.rs
@@ -1,16 +1,11 @@
 #![feature(test)]
 extern crate test;
 extern crate rand;
-extern crate fnv;
 extern crate lazy_static;
-
-use fnv::FnvHasher;
-use std::hash::BuildHasherDefault;
-type FnvBuilder = BuildHasherDefault<FnvHasher>;
 
 use test::Bencher;
 
-#[macro_use] extern crate ordermap;
+extern crate ordermap;
 
 use ordermap::OrderMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1050,6 +1050,8 @@ impl<K, V, S> OrderMap<K, V, S>
     }
 
     /// Sort the map’s key-value pairs by the default ordering of the keys.
+    ///
+    /// See `sort_by` for details.
     pub fn sort_keys(&mut self)
         where K: Ord,
     {
@@ -1061,6 +1063,8 @@ impl<K, V, S> OrderMap<K, V, S>
     ///
     /// The comparison function receives two key and value pairs to compare (you
     /// can sort by keys or values or their combination as needed).
+    ///
+    /// Computes in **O(n log n)** time and **O(n)** space. The sort is stable.
     pub fn sort_by<F>(&mut self, mut compare: F)
         where F: FnMut(&K, &V, &K, &V) -> Ordering,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1044,6 +1044,18 @@ impl<K, V, S> OrderMap<K, V, S>
         }
     }
 
+    /// Sort the map’s key-value pairs by the default ordering of the keys.
+    pub fn sort_keys(&mut self)
+        where K: Ord,
+    {
+        self.sort_by(|k1, _, k2, _| Ord::cmp(k1, k2))
+    }
+
+    /// Sort the map’s key-value pairs in place using the comparison
+    /// function `compare`.
+    ///
+    /// The comparison function receives two key and value pairs to compare (you
+    /// can sort by keys or values or their combination as needed).
     pub fn sort_by<F>(&mut self, mut compare: F)
         where F: FnMut(&K, &V, &K, &V) -> Ordering,
     {

--- a/src/set.rs
+++ b/src/set.rs
@@ -342,6 +342,20 @@ impl<T, S> OrderSet<T, S>
         self.map.retain(move |x, &mut ()| keep(x))
     }
 
+    /// Sort the set’s values by their default ordering.
+    pub fn sort(&mut self)
+        where T: Ord,
+    {
+        self.map.sort_keys()
+    }
+
+    /// Sort the set’s values in place using the comparison function `compare`.
+    pub fn sort_by<F>(&mut self, mut compare: F)
+        where F: FnMut(&T, &T) -> Ordering,
+    {
+        self.map.sort_by(move |a, _, b, _| compare(a, b));
+    }
+
     /// Sort the values of the set and return a by value iterator of
     /// the values with the result.
     ///

--- a/src/set.rs
+++ b/src/set.rs
@@ -343,6 +343,8 @@ impl<T, S> OrderSet<T, S>
     }
 
     /// Sort the set’s values by their default ordering.
+    ///
+    /// See `sort_by` for details.
     pub fn sort(&mut self)
         where T: Ord,
     {
@@ -350,6 +352,8 @@ impl<T, S> OrderSet<T, S>
     }
 
     /// Sort the set’s values in place using the comparison function `compare`.
+    ///
+    /// Computes in **O(n log n)** time and **O(n)** space. The sort is stable.
     pub fn sort_by<F>(&mut self, mut compare: F)
         where F: FnMut(&T, &T) -> Ordering,
     {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -273,6 +273,40 @@ quickcheck! {
         // check the order
         itertools::assert_equal(map.keys(), initial_map.keys().filter(|&k| !remove_map.contains_key(k)));
     }
+
+    fn sort_1(keyvals: Large<Vec<(i8, i8)>>) -> () {
+        let mut map: OrderMap<_, _> = OrderMap::from_iter(keyvals.to_vec());
+        let mut answer = keyvals.0;
+        answer.sort_by_key(|t| t.0);
+
+        // reverse dedup: Because OrderMap::from_iter keeps the last value for
+        // identical keys
+        answer.reverse();
+        answer.dedup_by_key(|t| t.0);
+        answer.reverse();
+
+        map.sort_by(|k1, _, k2, _| Ord::cmp(k1, k2));
+        let mapv = Vec::from_iter(map);
+        assert_eq!(answer, mapv);
+    }
+
+    fn sort_2(keyvals: Large<Vec<(i8, i8)>>) -> () {
+        let mut map: OrderMap<_, _> = OrderMap::from_iter(keyvals.to_vec());
+        map.sort_by(|_, v1, _, v2| Ord::cmp(v1, v2));
+        assert_sorted_by_key(map, |t| t.1);
+    }
+}
+
+fn assert_sorted_by_key<I, Key, X>(iterable: I, key: Key)
+    where I: IntoIterator,
+          I::Item: Ord + Clone + Debug,
+          Key: Fn(&I::Item) -> X,
+          X: Ord,
+{
+    let input = Vec::from_iter(iterable);
+    let mut sorted = input.clone();
+    sorted.sort_by_key(key);
+    assert_eq!(input, sorted);
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -286,8 +286,17 @@ quickcheck! {
         answer.reverse();
 
         map.sort_by(|k1, _, k2, _| Ord::cmp(k1, k2));
+
+        // check it contains all the values it should
+        for &(key, val) in &answer {
+            assert_eq!(map[&key], val);
+        }
+
+        // check the order
+
         let mapv = Vec::from_iter(map);
         assert_eq!(answer, mapv);
+
     }
 
     fn sort_2(keyvals: Large<Vec<(i8, i8)>>) -> () {


### PR DESCRIPTION
Implement an in place sorting method for OrderMap (and OrderSet). We use a very neat trick and temporarily save away the hash for each entry somewhere else and store the old index in the hash field. The benefit is that we can use `self.entries.sort_by` directly after that, which is very fast.

I don't think the extra allocation is avoidable (but we could have unstable sort too, avoiding *an* allocation).

Benchmarks from the current version, `sort` is the sorting algorithm in this PR. 

```rust
test ordermap_simple_sort_s                ... bench:   3,169,240 ns/iter (+/- 180,707)
test ordermap_simple_sort_u32              ... bench:     845,610 ns/iter (+/- 54,359)
test ordermap_sort_s                       ... bench:   2,550,010 ns/iter (+/- 279,423)
test ordermap_sort_u32                     ... bench:     678,828 ns/iter (+/- 10,313)
```

The maps have 10k key-value pairs. `s` is for `OrderMap<String, String>` and `u32` is for `OrderMap<u32, u32>`. As you can see, the simple implementation wins when the key/value types are simple.
  
  
  