### PR TITLE
Simplify and speed up the in-order preserve-order `.retain()`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -590,6 +590,17 @@ fn few_retain_ordermap_100_000(b: &mut Bencher) {
 }
 
 #[bench]
+fn few_retain_unordered_ordermap_100_000(b: &mut Bencher) {
+    let map = OMAP_100K.clone();
+
+    b.iter(|| {
+        let mut map = map.clone();
+        map.retain_unordered(|k, _| *k % 7 == 0);
+        map
+    });
+}
+
+#[bench]
 fn few_retain_hashmap_100_000(b: &mut Bencher) {
     let map = HMAP_100K.clone();
 
@@ -612,6 +623,17 @@ fn half_retain_ordermap_100_000(b: &mut Bencher) {
 }
 
 #[bench]
+fn half_retain_unordered_ordermap_100_000(b: &mut Bencher) {
+    let map = OMAP_100K.clone();
+
+    b.iter(|| {
+        let mut map = map.clone();
+        map.retain_unordered(|k, _| *k % 2 == 0);
+        map
+    });
+}
+
+#[bench]
 fn half_retain_hashmap_100_000(b: &mut Bencher) {
     let map = HMAP_100K.clone();
 
@@ -629,6 +651,17 @@ fn many_retain_ordermap_100_000(b: &mut Bencher) {
     b.iter(|| {
         let mut map = map.clone();
         map.retain(|k, _| *k % 100 != 0);
+        map
+    });
+}
+
+#[bench]
+fn many_retain_unordered_ordermap_100_000(b: &mut Bencher) {
+    let map = OMAP_100K.clone();
+
+    b.iter(|| {
+        let mut map = map.clone();
+        map.retain_unordered(|k, _| *k % 100 != 0);
         map
     });
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -590,17 +590,6 @@ fn few_retain_ordermap_100_000(b: &mut Bencher) {
 }
 
 #[bench]
-fn few_retain_unordered_ordermap_100_000(b: &mut Bencher) {
-    let map = OMAP_100K.clone();
-
-    b.iter(|| {
-        let mut map = map.clone();
-        map.retain_unordered(|k, _| *k % 7 == 0);
-        map
-    });
-}
-
-#[bench]
 fn few_retain_hashmap_100_000(b: &mut Bencher) {
     let map = HMAP_100K.clone();
 
@@ -623,17 +612,6 @@ fn half_retain_ordermap_100_000(b: &mut Bencher) {
 }
 
 #[bench]
-fn half_retain_unordered_ordermap_100_000(b: &mut Bencher) {
-    let map = OMAP_100K.clone();
-
-    b.iter(|| {
-        let mut map = map.clone();
-        map.retain_unordered(|k, _| *k % 2 == 0);
-        map
-    });
-}
-
-#[bench]
 fn half_retain_hashmap_100_000(b: &mut Bencher) {
     let map = HMAP_100K.clone();
 
@@ -651,17 +629,6 @@ fn many_retain_ordermap_100_000(b: &mut Bencher) {
     b.iter(|| {
         let mut map = map.clone();
         map.retain(|k, _| *k % 100 != 0);
-        map
-    });
-}
-
-#[bench]
-fn many_retain_unordered_ordermap_100_000(b: &mut Bencher) {
-    let map = OMAP_100K.clone();
-
-    b.iter(|| {
-        let mut map = map.clone();
-        map.retain_unordered(|k, _| *k % 100 != 0);
         map
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1002,19 +1002,6 @@ impl<K, V, S> OrderMap<K, V, S>
         self.retain_mut(move |k, v| keep(k, v));
     }
 
-    /// Scan through each key-value pair in the map and keep those where the
-    /// closure `keep` returns `true`.
-    ///
-    /// The order the elements are visited is not specified and removing
-    /// elements jumbles the order in the map.
-    ///
-    /// Computes in **O(n)** time (average).
-    pub fn retain_unordered<F>(&mut self, mut keep: F)
-        where F: FnMut(&K, &mut V) -> bool,
-    {
-        self.retain_unordered2(move |k, v| keep(&*k, v))
-    }
-
     fn retain_mut<F>(&mut self, keep: F)
         where F: FnMut(&mut K, &mut V) -> bool,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1234,24 +1234,22 @@ impl<K, V, S> OrderMap<K, V, S> {
     {
         // backward shift deletion in self.indices
         // after probe, shift all non-ideally placed indices backward
-        if self.len() > 0 {
-            let mut last_probe = probe_at_remove;
-            let mut probe = probe_at_remove + 1;
-            probe_loop!(probe < self.indices.len(), {
-                if let Some((i, hash_proxy)) = self.indices[probe].resolve::<Sz>() {
-                    let entry_hash = hash_proxy.get_short_hash(&self.entries, i);
-                    if probe_distance(self.mask, entry_hash.into_hash(), probe) > 0 {
-                        self.indices[last_probe] = self.indices[probe];
-                        self.indices[probe] = Pos::none();
-                    } else {
-                        break;
-                    }
+        let mut last_probe = probe_at_remove;
+        let mut probe = probe_at_remove + 1;
+        probe_loop!(probe < self.indices.len(), {
+            if let Some((i, hash_proxy)) = self.indices[probe].resolve::<Sz>() {
+                let entry_hash = hash_proxy.get_short_hash(&self.entries, i);
+                if probe_distance(self.mask, entry_hash.into_hash(), probe) > 0 {
+                    self.indices[last_probe] = self.indices[probe];
+                    self.indices[probe] = Pos::none();
                 } else {
                     break;
                 }
-                last_probe = probe;
-            });
-        }
+            } else {
+                break;
+            }
+            last_probe = probe;
+        });
     }
 
 }

--- a/src/mutable_keys.rs
+++ b/src/mutable_keys.rs
@@ -37,16 +37,6 @@ pub trait MutableKeys {
     fn retain2<F>(&mut self, keep: F)
         where F: FnMut(&mut Self::Key, &mut Self::Value) -> bool;
 
-    /// Scan through each key-value pair in the map and keep those where the
-    /// closure `keep` returns `true`.
-    ///
-    /// The order the elements are visited is not specified and removing
-    /// elements jumbles the order in the map.
-    ///
-    /// Computes in **O(n)** time (average).
-    fn retain_unordered2<F>(&mut self, keep: F)
-        where F: FnMut(&mut Self::Key, &mut Self::Value) -> bool;
-
     /// This method is not useful in itself – it is there to “seal” the trait
     /// for external implementation, so that we can add methods without
     /// causing breaking changes.
@@ -78,25 +68,6 @@ impl<K, V, S> MutableKeys for OrderMap<K, V, S>
         where F: FnMut(&mut K, &mut V) -> bool,
     {
         self.retain_mut(keep)
-    }
-
-    fn retain_unordered2<F>(&mut self, mut keep: F)
-        where F: FnMut(&mut K, &mut V) -> bool,
-    {
-        // We can use either forward or reverse scan, but forward was
-        // faster in a microbenchmark
-        let mut i = 0;
-        while i < self.len() {
-            {
-                let entry = &mut self.entries[i];
-                if keep(&mut entry.key, &mut entry.value) {
-                    i += 1;
-                    continue;
-                }
-            }
-            self.swap_remove_index(i);
-            // skip increment on remove
-        }
     }
 
     fn __private_marker(&self) -> PrivateMarker {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -273,35 +273,6 @@ quickcheck! {
         // check the order
         itertools::assert_equal(map.keys(), initial_map.keys().filter(|&k| !remove_map.contains_key(k)));
     }
-
-    // Check that retain unordered visits each key exactly once
-    fn retain_visit(keys: Large<Vec<i8>>, remove: Large<Vec<i8>>) -> () {
-        let mut map = ordermap(keys.iter());
-        let initial_map = map.clone();
-        let mut visit = OrderMap::with_capacity(map.len());
-        let remove_map = ordermap(remove.iter());
-        map.retain_unordered(|k, _| {
-            *visit.entry(*k).or_insert(0) += 1;
-            !remove_map.contains_key(k)
-        });
-
-        assert_eq!(visit.len(), initial_map.len());
-        assert!(visit.iter().all(|(_, v)| *v == 1));
-    }
-
-    fn retain_unordered(keys: Large<Vec<i8>>, remove: Large<Vec<i8>>) -> () {
-        let mut map = ordermap(keys.iter());
-        let remove_map = ordermap(remove.iter());
-        let keys_s = set(keys.iter());
-        let remove_s = set(remove.iter());
-        let answer = &keys_s - &remove_s;
-        map.retain_unordered(|k, _| !remove_map.contains_key(k));
-        assert_eq!(map.len(), answer.len());
-        for key in &answer {
-            assert!(map.contains_key(key));
-        }
-    }
-
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]


### PR DESCRIPTION
The new retain was just merged yesterday, but some successive improvements and tweaks of this code resulted in the following much simpler and more efficient version.

- Remove `.retain_unordered()` again (this method has been in no released version), because regular in order retain is the fastest anyway for many cases. Unlike `retain`, users can reimplement `.retain_unordered` externally using the available public methods.

Improvement in this PR:



```
 name                                    63 ns/iter  62 ns/iter  diff ns/iter   diff % 
 few_retain_ordermap_100_000             3,789,865   2,650,688     -1,139,177  -30.06% 
 half_retain_ordermap_100_000            3,928,837   2,735,071     -1,193,766  -30.38% 
 many_retain_ordermap_100_000            3,574,726   2,332,965     -1,241,761  -34.74% 
```
(few, half, many refers to how big fraction of elements are retained)

Comparison with `HashMap` `retain` and with `OrderMap` `retain_unordered`:

```rust
 name                                                ns/iter
 few_retain_hashmap_100_000                          1,533,783
 few_retain_ordermap_100_000                         2,650,688
 few_retain_unordered_ordermap_100_000               3,126,817
 half_retain_hashmap_100_000                         1,669,931
 half_retain_ordermap_100_000                        2,735,071
 half_retain_unordered_ordermap_100_000              2,875,135
 many_retain_hashmap_100_000                         703,414  
 many_retain_ordermap_100_000                        2,332,965
 many_retain_unordered_ordermap_100_000              1,374,794
```
  
  