### PR TITLE
Factor out "OrderMapCore" and other generics bloat saving measures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,15 +688,7 @@ impl<K, V, S> OrderMap<K, V, S>
     ///
     /// Computes in **O(n)** time.
     pub fn clear(&mut self) {
-        self.core.entries.clear();
-        self.clear_indices();
-    }
-
-    // clear self.core.indices to the same state as "no elements"
-    fn clear_indices(&mut self) {
-        for pos in self.core.indices.iter_mut() {
-            *pos = Pos::none();
-        }
+        self.core.clear();
     }
 
     /// Reserve capacity for `additional` more key-value pairs.
@@ -980,7 +972,7 @@ impl<K, V, S> OrderMap<K, V, S>
     /// Clears the `OrderMap`, returning all key-value pairs as a drain iterator.
     /// Keeps the allocated memory for reuse.
     pub fn drain(&mut self, range: RangeFull) -> Drain<K, V> {
-        self.clear_indices();
+        self.core.clear_indices();
 
         Drain {
             iter: self.core.entries.drain(range),
@@ -1040,6 +1032,18 @@ impl<K, V> OrderMapCore<K, V> {
 
     fn capacity(&self) -> usize {
         usable_capacity(self.raw_capacity())
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.clear_indices();
+    }
+
+    // clear self.indices to the same state as "no elements"
+    fn clear_indices(&mut self) {
+        for pos in self.indices.iter_mut() {
+            *pos = Pos::none();
+        }
     }
 
     fn first_allocation(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1079,7 +1079,7 @@ impl<K, V, S> OrderMap<K, V, S>
     pub fn sort_keys(&mut self)
         where K: Ord,
     {
-        self.sort_by(|k1, _, k2, _| Ord::cmp(k1, k2))
+        self.core.sort_by(key_cmp)
     }
 
     /// Sort the map’s key-value pairs in place using the comparison
@@ -1116,6 +1116,12 @@ impl<K, V, S> OrderMap<K, V, S>
             iter: self.core.entries.drain(range),
         }
     }
+}
+
+fn key_cmp<K, V>(k1: &K, _v1: &V, k2: &K, _v2: &V) -> Ordering
+    where K: Ord
+{
+    Ord::cmp(k1, k2)
 }
 
 impl<K, V, S> OrderMap<K, V, S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,9 +560,6 @@ macro_rules! dispatch_32_vs_64 {
 
 /// Entry for an existing key-value pair or a vacant location to
 /// insert one.
-///
-/// FIXME: Remove dependence on the `S` parameter
-/// (to match HashMap).
 pub enum Entry<'a, K: 'a, V: 'a> {
     /// Existing slot with equivalent key.
     Occupied(OccupiedEntry<'a, K, V>),
@@ -679,7 +676,7 @@ impl<K, V, S> OrderMap<K, V, S>
     where K: Hash + Eq,
           S: BuildHasher,
 {
-    // Warning, this is a code duplication zone Entry is not yet finished
+    // FIXME: reduce duplication (compare with insert)
     fn entry_phase_1<Sz>(&mut self, key: K) -> Entry<K, V>
         where Sz: Size
     {

--- a/src/mutable_keys.rs
+++ b/src/mutable_keys.rs
@@ -57,7 +57,7 @@ impl<K, V, S> MutableKeys for OrderMap<K, V, S>
         where Q: Hash + Equivalent<K>,
     {
         if let Some((_, found)) = self.find(key) {
-            let entry = &mut self.entries[found];
+            let entry = &mut self.core.entries[found];
             Some((found, &mut entry.key, &mut entry.value))
         } else {
             None

--- a/src/set.rs
+++ b/src/set.rs
@@ -409,12 +409,12 @@ pub struct IntoIter<T> {
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
 
-    iterator_methods!(|entry| entry.key);
+    iterator_methods!(Bucket::key);
 }
 
 impl<T> DoubleEndedIterator for IntoIter<T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|entry| entry.key)
+        self.iter.next_back().map(Bucket::key)
     }
 }
 
@@ -432,12 +432,12 @@ pub struct Iter<'a, T: 'a> {
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
-    iterator_methods!(|entry| &entry.key);
+    iterator_methods!(Bucket::key_ref);
 }
 
 impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|entry| &entry.key)
+        self.iter.next_back().map(Bucket::key_ref)
     }
 }
 
@@ -454,11 +454,11 @@ pub struct Drain<'a, T: 'a> {
 impl<'a, T> Iterator for Drain<'a, T> {
     type Item = T;
 
-    iterator_methods!(|bucket| bucket.key);
+    iterator_methods!(Bucket::key);
 }
 
 impl<'a, T> DoubleEndedIterator for Drain<'a, T> {
-    double_ended_iterator_methods!(|bucket| bucket.key);
+    double_ended_iterator_methods!(Bucket::key);
 }
 
 impl<'a, T, S> IntoIterator for &'a OrderSet<T, S>


### PR DESCRIPTION
For each compiled item we ideally want it to depend on the least amount of type parameters, so that it can be shared between different parameterizations of OrderMap. To this end, factor out the part of ordermap that does not depend on S (the hasher). This also seems like a cleaner design, even if it needs some more wrapper methods.

As a bonus, this resolves the issue where we had one more parameter than the standard `HashMap`'s `Entry<K, V>` -- ordermap's entry is now identical.

Also reduce the number of closures used in the iterators.