### PR TITLE
Docs & Relnote for ordermap 0.4.0 (the last release series under this name)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,23 @@ Ideas that we already did
 Recent Changes
 ==============
 
+- 0.4.0
+
+  - This is the last release series for this ``ordermap`` under that name,
+    because the crate is **going to be renamed** to ``indexmap`` (with types
+    ``IndexMap``, ``IndexSet``) and no change in functionality!
+  - The map and its associated structs moved into the ``map`` submodule of the
+    crate, so that the map and set are symmetric
+
+    + The iterators, ``Entry`` and other structs are now under ``ordermap::map::``
+
+  - Internally refactored ``OrderMap<K, V, S>`` so that all the main algorithms
+    (insertion, lookup, removal etc) that don't use the ``S`` parameter (the
+    hasher) are compiled without depending on ``S``, which reduces generics bloat.
+
+  - ``Entry<K, V>`` no longer has a type parameter ``S``, which is just like
+    the standard ``HashMap``'s entry.
+
 - 0.3.5
 
   - Documentation improvements

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,11 @@
 //! [`OrderMap`] is a hash table where the iteration order of the key-value
 //! pairs is independent of the hash values of the keys.
 //!
-//! [`OrderMap`]: struct.OrderMap.html
+//! [`OrderSet`] is a corresponding hash set using the same implementation and
+//! with similar properties.
+//!
+//! [`OrderMap`]: map/struct.OrderMap.html
+//! [`OrderSet`]: set/struct.OrderSet.html
 
 #[macro_use]
 mod macros;

--- a/src/map.rs
+++ b/src/map.rs
@@ -238,6 +238,10 @@ impl<Sz> ShortHashProxy<Sz>
 ///
 /// All iterators traverse the map in *the order*.
 ///
+/// The insertion order is preserved, with **notable exceptions** like the
+/// `.remove()` or `.swap_remove()` methods. Methods such as `.sort_by()` of
+/// course result in a new order, depending on the sorting order.
+///
 /// # Indices
 ///
 /// The key-value pairs are indexed in a compact range without holes in the

--- a/src/set.rs
+++ b/src/set.rs
@@ -32,6 +32,10 @@ type Bucket<T> = super::Bucket<T, ()>;
 /// `union` produce a concatenated order, as do their matching "bitwise"
 /// operators.  See their documentation for specifics.
 ///
+/// The insertion order is preserved, with **notable exceptions** like the
+/// `.remove()` or `.swap_remove()` methods. Methods such as `.sort_by()` of
+/// course result in a new order, depending on the sorting order.
+///
 /// # Indices
 ///
 /// The values are indexed in a compact range without holes in the range


### PR DESCRIPTION
The idea is to introduce deprecations and IndexMap type aliases in 0.4.1