### PR TITLE
Add deprecation notice to OrderMap/Set to prepare for rename to indexmap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@ pub mod set;
 pub mod map;
 
 pub use equivalent::Equivalent;
+#[allow(deprecated)]
 pub use set::OrderSet;
+#[allow(deprecated)]
 pub use map::OrderMap;
 
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 
 //! [`OrderMap`] is a hash table where the iteration order of the key-value
 //! pairs is independent of the hash values of the keys.
@@ -263,6 +264,9 @@ impl<Sz> ShortHashProxy<Sz>
 /// assert_eq!(letters.get(&'y'), None);
 /// ```
 #[derive(Clone)]
+#[allow(deprecated)]
+#[deprecated(note = "the crate ordermap has been renamed with no change in \
+              functionality to indexmap; please update your dependencies")]
 pub struct OrderMap<K, V, S = RandomState> {
     core: OrderMapCore<K, V>,
     hash_builder: S,

--- a/src/mutable_keys.rs
+++ b/src/mutable_keys.rs
@@ -2,6 +2,7 @@
 use std::hash::Hash;
 use std::hash::BuildHasher;
 
+#[allow(deprecated)]
 use super::{OrderMap, Equivalent};
 
 pub struct PrivateMarker { }
@@ -43,6 +44,7 @@ pub trait MutableKeys {
     fn __private_marker(&self) -> PrivateMarker;
 }
 
+#[allow(deprecated)]
 /// Opt-in mutable access to keys.
 ///
 /// See [`MutableKeys`](trait.MutableKeys.html) for more information.

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,5 @@
 //! A hash set implemented using `OrderMap`
+#![allow(deprecated)]
 
 use std::cmp::Ordering;
 use std::collections::hash_map::RandomState;
@@ -56,6 +57,8 @@ type Bucket<T> = super::Bucket<T, ()>;
 /// assert!(!letters.contains(&'y'));
 /// ```
 #[derive(Clone)]
+#[deprecated(note = "the crate ordermap has been renamed with no change in \
+              functionality to indexmap; please update your dependencies")]
 pub struct OrderSet<T, S = RandomState> {
     map: OrderMap<T, (), S>,
 }


### PR DESCRIPTION
It's possible to put the deprecation on the crate itself, but then users
get a ridiculous onslaught of messages for each item (including methods)
used from the crate. So we put the notice on OrderMap and OrderSet
themselves.