### PR TITLE
Rename OrderMap to IndexMap; rename crate to indexmap (and OrderSet to IndexSet)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "ordermap"
+name = "indexmap"
 version = "0.4.1"
 authors = ["bluss"]
-documentation = "https://docs.rs/ordermap/"
-repository = "https://github.com/bluss/ordermap"
+documentation = "https://docs.rs/indexmap/"
+repository = "https://github.com/bluss/indexmap"
 license = "Apache-2.0/MIT"
 description = "A hash table with consistent order and fast iteration."
 

--- a/README.rst
+++ b/README.rst
@@ -3,16 +3,22 @@ Awesome hash table implementation in just Rust (stable, no unsafe code).
 
 Please read the `API documentation here`__
 
-__ https://docs.rs/ordermap/
+__ https://docs.rs/indexmap/
 
 |build_status|_ |crates|_
 
-.. |crates| image:: https://img.shields.io/crates/v/ordermap.svg
-.. _crates: https://crates.io/crates/ordermap
+.. |crates| image:: https://img.shields.io/crates/v/indexmap.svg
+.. _crates: https://crates.io/crates/indexmap
 
-.. |build_status| image:: https://travis-ci.org/bluss/ordermap.svg
-.. _build_status: https://travis-ci.org/bluss/ordermap
+.. |build_status| image:: https://travis-ci.org/bluss/indexmap.svg
+.. _build_status: https://travis-ci.org/bluss/indexmap
 
+Crate Name
+==========
+
+This crate was originally released under the name ``ordermap``, but it was
+renamed (with no change in functionality) to ``indexmap`` to better emphasize
+its features.
 
 Background
 ==========
@@ -21,7 +27,7 @@ This was inspired by Python 3.6's new dict implementation (which remembers
 the insertion order and is fast to iterate, and is compact in memory).
 
 Some of those features were translated to Rust, and some were not. The result
-was ordermap, a hash table that has following properties:
+was indexmap, a hash table that has following properties:
 
 - Order is **independent of hash function** and hash values of keys.
 - Fast to iterate.

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Does not implement (Yet)
 Performance
 -----------
 
-``OrderMap`` derives a couple of performance facts directly from how it is constructed,
+``IndexMap`` derives a couple of performance facts directly from how it is constructed,
 which is roughly:
 
   Two vectors, the first, sparse, with hashes and key-value indices, and the
@@ -53,9 +53,9 @@ which is roughly:
   Lookup also is slow-ish since hashes and key-value pairs are stored in
   separate places. (Visible when cpu caches size is limiting.)
 
-- In practice, ``OrderMap`` has been tested out as the hashmap in rustc in PR45282_ and
+- In practice, ``IndexMap`` has been tested out as the hashmap in rustc in PR45282_ and
   the performance was roughly on par across the whole workload. 
-- If you want the properties of ``OrderMap``, or its strongest performance points
+- If you want the properties of ``IndexMap``, or its strongest performance points
   fits your workload, it might be the best hash table implementation.
 
 .. _PR45282: https://github.com/rust-lang/rust/pull/45282
@@ -65,7 +65,7 @@ Interesting Features
 
 - Insertion order is preserved (``.swap_remove()`` perturbs the order, like the method name says).
 - Implements ``.pop() -> Option<(K, V)>`` in O(1) time.
-- ``OrderMap::new()`` is empty and uses no allocation until you insert something.
+- ``IndexMap::new()`` is empty and uses no allocation until you insert something.
 - Lookup key-value pairs by index and vice versa.
 - No ``unsafe``.
 - Supports ``IndexMut``.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -13,9 +13,9 @@ type FnvBuilder = BuildHasherDefault<FnvHasher>;
 use test::Bencher;
 use test::black_box;
 
-extern crate ordermap;
+extern crate indexmap;
 
-use ordermap::IndexMap;
+use indexmap::IndexMap;
 
 use std::collections::HashMap;
 use std::iter::FromIterator;

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -15,7 +15,7 @@ use test::black_box;
 
 extern crate ordermap;
 
-use ordermap::OrderMap;
+use ordermap::IndexMap;
 
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -32,7 +32,7 @@ fn new_hashmap(b: &mut Bencher) {
 #[bench]
 fn new_orderedmap(b: &mut Bencher) {
     b.iter(|| {
-        OrderMap::<String, String>::new()
+        IndexMap::<String, String>::new()
     });
 }
 
@@ -46,7 +46,7 @@ fn with_capacity_10e5_hashmap(b: &mut Bencher) {
 #[bench]
 fn with_capacity_10e5_orderedmap(b: &mut Bencher) {
     b.iter(|| {
-        OrderMap::<String, String>::with_capacity(10_000)
+        IndexMap::<String, String>::with_capacity(10_000)
     });
 }
 
@@ -66,7 +66,7 @@ fn insert_hashmap_10_000(b: &mut Bencher) {
 fn insert_orderedmap_10_000(b: &mut Bencher) {
     let c = 10_000;
     b.iter(|| {
-        let mut map = OrderMap::with_capacity(c);
+        let mut map = IndexMap::with_capacity(c);
         for x in 0..c {
             map.insert(x, ());
         }
@@ -90,7 +90,7 @@ fn insert_hashmap_string_10_000(b: &mut Bencher) {
 fn insert_orderedmap_string_10_000(b: &mut Bencher) {
     let c = 10_000;
     b.iter(|| {
-        let mut map = OrderMap::with_capacity(c);
+        let mut map = IndexMap::with_capacity(c);
         for x in 0..c {
             map.insert(x.to_string(), ());
         }
@@ -116,7 +116,7 @@ fn insert_orderedmap_str_10_000(b: &mut Bencher) {
     let c = 10_000;
     let ss = Vec::from_iter((0..c).map(|x| x.to_string()));
     b.iter(|| {
-        let mut map = OrderMap::with_capacity(c);
+        let mut map = IndexMap::with_capacity(c);
         for key in &ss {
             map.insert(&key[..], ());
         }
@@ -142,7 +142,7 @@ fn insert_orderedmap_int_bigvalue_10_000(b: &mut Bencher) {
     let c = 10_000;
     let value = [0u64; 10];
     b.iter(|| {
-        let mut map = OrderMap::with_capacity(c);
+        let mut map = IndexMap::with_capacity(c);
         for i in 0..c {
             map.insert(i, value);
         }
@@ -166,7 +166,7 @@ fn insert_hashmap_100_000(b: &mut Bencher) {
 fn insert_orderedmap_100_000(b: &mut Bencher) {
     let c = 100_000;
     b.iter(|| {
-        let mut map = OrderMap::with_capacity(c);
+        let mut map = IndexMap::with_capacity(c);
         for x in 0..c {
             map.insert(x, ());
         }
@@ -190,7 +190,7 @@ fn insert_hashmap_150(b: &mut Bencher) {
 fn insert_orderedmap_150(b: &mut Bencher) {
     let c = 150;
     b.iter(|| {
-        let mut map = OrderMap::with_capacity(c);
+        let mut map = IndexMap::with_capacity(c);
         for x in 0..c {
             map.insert(x, ());
         }
@@ -214,7 +214,7 @@ fn entry_hashmap_150(b: &mut Bencher) {
 fn entry_orderedmap_150(b: &mut Bencher) {
     let c = 150;
     b.iter(|| {
-        let mut map = OrderMap::with_capacity(c);
+        let mut map = IndexMap::with_capacity(c);
         for x in 0..c {
             map.entry(x).or_insert(());
         }
@@ -239,7 +239,7 @@ fn iter_sum_hashmap_10_000(b: &mut Bencher) {
 #[bench]
 fn iter_sum_orderedmap_10_000(b: &mut Bencher) {
     let c = 10_000;
-    let mut map = OrderMap::with_capacity(c);
+    let mut map = IndexMap::with_capacity(c);
     let len = c - c/10;
     for x in 0..len {
         map.insert(x, ());
@@ -269,7 +269,7 @@ fn iter_black_box_hashmap_10_000(b: &mut Bencher) {
 #[bench]
 fn iter_black_box_orderedmap_10_000(b: &mut Bencher) {
     let c = 10_000;
-    let mut map = OrderMap::with_capacity(c);
+    let mut map = IndexMap::with_capacity(c);
     let len = c - c/10;
     for x in 0..len {
         map.insert(x, ());
@@ -328,7 +328,7 @@ fn lookup_hashmap_10_000_noexist(b: &mut Bencher) {
 #[bench]
 fn lookup_orderedmap_10_000_exist(b: &mut Bencher) {
     let c = 10_000;
-    let mut map = OrderMap::with_capacity(c);
+    let mut map = IndexMap::with_capacity(c);
     let keys = shuffled_keys(0..c);
     for &key in &keys {
         map.insert(key, 1);
@@ -345,7 +345,7 @@ fn lookup_orderedmap_10_000_exist(b: &mut Bencher) {
 #[bench]
 fn lookup_orderedmap_10_000_noexist(b: &mut Bencher) {
     let c = 10_000;
-    let mut map = OrderMap::with_capacity(c);
+    let mut map = IndexMap::with_capacity(c);
     let keys = shuffled_keys(0..c);
     for &key in &keys {
         map.insert(key, 1);
@@ -385,9 +385,9 @@ lazy_static! {
 }
 
 lazy_static! {
-    static ref OMAP_100K: OrderMap<u32, u32> = {
+    static ref OMAP_100K: IndexMap<u32, u32> = {
         let c = LOOKUP_MAP_SIZE;
-        let mut map = OrderMap::with_capacity(c as usize);
+        let mut map = IndexMap::with_capacity(c as usize);
         let keys = &*KEYS;
         for &key in keys {
             map.insert(key, key);
@@ -397,8 +397,8 @@ lazy_static! {
 }
 
 lazy_static! {
-    static ref OMAP_SORT_U32: OrderMap<u32, u32> = {
-        let mut map = OrderMap::with_capacity(SORT_MAP_SIZE);
+    static ref OMAP_SORT_U32: IndexMap<u32, u32> = {
+        let mut map = IndexMap::with_capacity(SORT_MAP_SIZE);
         for &key in &KEYS[..SORT_MAP_SIZE] {
             map.insert(key, key);
         }
@@ -406,8 +406,8 @@ lazy_static! {
     };
 }
 lazy_static! {
-    static ref OMAP_SORT_S: OrderMap<String, String> = {
-        let mut map = OrderMap::with_capacity(SORT_MAP_SIZE);
+    static ref OMAP_SORT_S: IndexMap<String, String> = {
+        let mut map = IndexMap::with_capacity(SORT_MAP_SIZE);
         for &key in &KEYS[..SORT_MAP_SIZE] {
             map.insert(format!("{:^16x}", &key), String::new());
         }
@@ -507,7 +507,7 @@ fn grow_fnv_hashmap_100_000(b: &mut Bencher) {
 #[bench]
 fn grow_fnv_ordermap_100_000(b: &mut Bencher) {
     b.iter(|| {
-        let mut map: OrderMap<_, _, FnvBuilder> = OrderMap::default();
+        let mut map: IndexMap<_, _, FnvBuilder> = IndexMap::default();
         for x in 0..GROW_SIZE {
             map.insert(x as GrowKey, x as GrowKey);
         }
@@ -546,8 +546,8 @@ fn hashmap_merge_shuffle(b: &mut Bencher) {
 
 #[bench]
 fn ordermap_merge_simple(b: &mut Bencher) {
-    let first_map: OrderMap<u64, _> = (0..MERGE).map(|i| (i, ())).collect();
-    let second_map: OrderMap<u64, _> = (MERGE..MERGE * 2).map(|i| (i, ())).collect();
+    let first_map: IndexMap<u64, _> = (0..MERGE).map(|i| (i, ())).collect();
+    let second_map: IndexMap<u64, _> = (MERGE..MERGE * 2).map(|i| (i, ())).collect();
     b.iter(|| {
         let mut merged = first_map.clone();
         merged.extend(second_map.iter().map(|(&k, &v)| (k, v)));
@@ -557,8 +557,8 @@ fn ordermap_merge_simple(b: &mut Bencher) {
 
 #[bench]
 fn ordermap_merge_shuffle(b: &mut Bencher) {
-    let first_map: OrderMap<u64, _> = (0..MERGE).map(|i| (i, ())).collect();
-    let second_map: OrderMap<u64, _> = (MERGE..MERGE * 2).map(|i| (i, ())).collect();
+    let first_map: IndexMap<u64, _> = (0..MERGE).map(|i| (i, ())).collect();
+    let second_map: IndexMap<u64, _> = (MERGE..MERGE * 2).map(|i| (i, ())).collect();
     let mut v = Vec::new();
     let mut rng = weak_rng();
     b.iter(|| {
@@ -669,7 +669,7 @@ fn many_retain_hashmap_100_000(b: &mut Bencher) {
 
 
 // simple sort impl for comparison
-pub fn simple_sort<K: Ord + Hash, V>(m: &mut OrderMap<K, V>) {
+pub fn simple_sort<K: Ord + Hash, V>(m: &mut IndexMap<K, V>) {
     let mut ordered: Vec<_> = m.drain(..).collect();
     ordered.sort_by(|left, right| left.0.cmp(&right.0));
     m.extend(ordered);

--- a/benches/faststring.rs
+++ b/benches/faststring.rs
@@ -5,9 +5,9 @@ extern crate lazy_static;
 
 use test::Bencher;
 
-extern crate ordermap;
+extern crate indexmap;
 
-use ordermap::IndexMap;
+use indexmap::IndexMap;
 
 use std::collections::HashMap;
 use std::iter::FromIterator;

--- a/benches/faststring.rs
+++ b/benches/faststring.rs
@@ -7,7 +7,7 @@ use test::Bencher;
 
 extern crate ordermap;
 
-use ordermap::OrderMap;
+use ordermap::IndexMap;
 
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -102,7 +102,7 @@ fn insert_hashmap_string_oneshot_10_000(b: &mut Bencher) {
 fn insert_orderedmap_string_10_000(b: &mut Bencher) {
     let c = 10_000;
     b.iter(|| {
-        let mut map = OrderMap::with_capacity(c);
+        let mut map = IndexMap::with_capacity(c);
         for x in 0..c {
             map.insert(x.to_string(), ());
         }
@@ -149,7 +149,7 @@ fn lookup_hashmap_10_000_exist_string_oneshot(b: &mut Bencher) {
 #[bench]
 fn lookup_ordermap_10_000_exist_string(b: &mut Bencher) {
     let c = 10_000;
-    let mut map = OrderMap::with_capacity(c);
+    let mut map = IndexMap::with_capacity(c);
     let keys = shuffled_keys(0..c);
     for &key in &keys {
         map.insert(key.to_string(), 1);
@@ -167,7 +167,7 @@ fn lookup_ordermap_10_000_exist_string(b: &mut Bencher) {
 #[bench]
 fn lookup_ordermap_10_000_exist_string_oneshot(b: &mut Bencher) {
     let c = 10_000;
-    let mut map = OrderMap::with_capacity(c);
+    let mut map = IndexMap::with_capacity(c);
     let keys = shuffled_keys(0..c);
     for &key in &keys {
         map.insert(OneShot(key.to_string()), 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 
 #![deny(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/ordermap/0.4/")]
+#![doc(html_root_url = "https://docs.rs/indexmap/0.4/")]
 
-//! [`OrderMap`] is a hash table where the iteration order of the key-value
+//! [`IndexMap`] is a hash table where the iteration order of the key-value
 //! pairs is independent of the hash values of the keys.
 //!
-//! [`OrderSet`] is a corresponding hash set using the same implementation and
+//! [`IndexSet`] is a corresponding hash set using the same implementation and
 //! with similar properties.
 //!
-//! [`OrderMap`]: map/struct.OrderMap.html
-//! [`OrderSet`]: set/struct.OrderSet.html
+//! [`IndexMap`]: map/struct.IndexMap.html
+//! [`IndexSet`]: set/struct.IndexSet.html
 
 #[macro_use]
 mod macros;
@@ -23,11 +23,12 @@ pub mod set;
 pub mod map;
 
 pub use equivalent::Equivalent;
-#[allow(deprecated)]
-pub use set::OrderSet;
+pub use map::IndexMap;
+pub use set::IndexSet;
 #[allow(deprecated)]
 pub use map::OrderMap;
-
+#[allow(deprecated)]
+pub use set::OrderSet;
 
 // shared private items
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 
 #[macro_export]
-/// Create an `OrderMap` from a list of key-value pairs
+/// Create an `IndexMap` from a list of key-value pairs
 ///
 /// ## Example
 ///
@@ -28,7 +28,7 @@ macro_rules! ordermap {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = ordermap!(@count $($key),*);
-            let mut _map = $crate::OrderMap::with_capacity(_cap);
+            let mut _map = $crate::IndexMap::with_capacity(_cap);
             $(
                 _map.insert($key, $value);
             )*
@@ -38,7 +38,7 @@ macro_rules! ordermap {
 }
 
 #[macro_export]
-/// Create an `OrderSet` from a list of values
+/// Create an `IndexSet` from a list of values
 ///
 /// ## Example
 ///
@@ -66,7 +66,7 @@ macro_rules! orderset {
     ($($value:expr),*) => {
         {
             let _cap = orderset!(@count $($value),*);
-            let mut _set = $crate::OrderSet::with_capacity(_cap);
+            let mut _set = $crate::IndexSet::with_capacity(_cap);
             $(
                 _set.insert($value);
             )*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,6 +37,12 @@ macro_rules! indexmap {
     };
 }
 
+#[deprecated(note = "renamed to indexmap!{ }")]
+#[macro_export]
+macro_rules! ordermap {
+    ($($t:tt)*) => { indexmap!($($t)*) }
+}
+
 #[macro_export]
 /// Create an `IndexSet` from a list of values
 ///
@@ -73,6 +79,12 @@ macro_rules! indexset {
             _set
         }
     };
+}
+
+#[deprecated(note = "renamed to indexset!{ }")]
+#[macro_export]
+macro_rules! orderset {
+    ($($t:tt)*) => { indexset!($($t)*) }
 }
 
 // generate all the Iterator methods by just forwarding to the underlying

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,10 +5,10 @@
 /// ## Example
 ///
 /// ```
-/// #[macro_use] extern crate ordermap;
+/// #[macro_use] extern crate indexmap;
 /// # fn main() {
 ///
-/// let map = ordermap!{
+/// let map = indexmap!{
 ///     "a" => 1,
 ///     "b" => 2,
 /// };
@@ -20,14 +20,14 @@
 /// assert_eq!(map.keys().next(), Some(&"a"));
 /// # }
 /// ```
-macro_rules! ordermap {
+macro_rules! indexmap {
     (@single $($x:tt)*) => (());
-    (@count $($rest:expr),*) => (<[()]>::len(&[$(ordermap!(@single $rest)),*]));
+    (@count $($rest:expr),*) => (<[()]>::len(&[$(indexmap!(@single $rest)),*]));
 
-    ($($key:expr => $value:expr,)+) => { ordermap!($($key => $value),+) };
+    ($($key:expr => $value:expr,)+) => { indexmap!($($key => $value),+) };
     ($($key:expr => $value:expr),*) => {
         {
-            let _cap = ordermap!(@count $($key),*);
+            let _cap = indexmap!(@count $($key),*);
             let mut _map = $crate::IndexMap::with_capacity(_cap);
             $(
                 _map.insert($key, $value);
@@ -43,10 +43,10 @@ macro_rules! ordermap {
 /// ## Example
 ///
 /// ```
-/// #[macro_use] extern crate ordermap;
+/// #[macro_use] extern crate indexmap;
 /// # fn main() {
 ///
-/// let set = orderset!{
+/// let set = indexset!{
 ///     "a",
 ///     "b",
 /// };
@@ -58,14 +58,14 @@ macro_rules! ordermap {
 /// assert_eq!(set.iter().next(), Some(&"a"));
 /// # }
 /// ```
-macro_rules! orderset {
+macro_rules! indexset {
     (@single $($x:tt)*) => (());
-    (@count $($rest:expr),*) => (<[()]>::len(&[$(orderset!(@single $rest)),*]));
+    (@count $($rest:expr),*) => (<[()]>::len(&[$(indexset!(@single $rest)),*]));
 
-    ($($value:expr,)+) => { orderset!($($value),+) };
+    ($($value:expr,)+) => { indexset!($($value),+) };
     ($($value:expr),*) => {
         {
-            let _cap = orderset!(@count $($value),*);
+            let _cap = indexset!(@count $($value),*);
             let mut _set = $crate::IndexSet::with_capacity(_cap);
             $(
                 _set.insert($value);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,6 +37,7 @@ macro_rules! indexmap {
     };
 }
 
+/// Old name; use [`indexmap!{}`](macro.indexmap.html) instead.
 #[deprecated(note = "renamed to indexmap!{ }")]
 #[macro_export]
 macro_rules! ordermap {
@@ -81,6 +82,7 @@ macro_rules! indexset {
     };
 }
 
+/// Old name; use [`indexset!{}`](macro.indexset.html) instead.
 #[deprecated(note = "renamed to indexset!{ }")]
 #[macro_export]
 macro_rules! orderset {

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,9 +1,7 @@
-#![allow(deprecated)]
-
-//! [`OrderMap`] is a hash table where the iteration order of the key-value
+//! [`IndexMap`] is a hash table where the iteration order of the key-value
 //! pairs is independent of the hash values of the keys.
 //!
-//! [`OrderMap`]: struct.OrderMap.html
+//! [`IndexMap`]: struct.IndexMap.html
 
 pub use mutable_keys::MutableKeys;
 
@@ -89,7 +87,7 @@ impl<Sz> From<ShortHash<Sz>> for HashValue {
 /// Note that the lower 32 bits of the hash is enough to compute desired
 /// position and probe distance in a hash map with less than 2**32 buckets.
 ///
-/// The OrderMap will simply query its **current raw capacity** to see what its
+/// The IndexMap will simply query its **current raw capacity** to see what its
 /// current size class is, and dispatch to the 32-bit or 64-bit lookup code as
 /// appropriate. Only the growth code needs some extra logic to handle the
 /// transition from one class to another
@@ -250,10 +248,10 @@ impl<Sz> ShortHashProxy<Sz>
 /// # Examples
 ///
 /// ```
-/// use ordermap::OrderMap;
+/// use ordermap::IndexMap;
 ///
 /// // count the frequency of each letter in a sentence.
-/// let mut letters = OrderMap::new();
+/// let mut letters = IndexMap::new();
 /// for ch in "a short treatise on fungi".chars() {
 ///     *letters.entry(ch).or_insert(0) += 1;
 /// }
@@ -264,13 +262,13 @@ impl<Sz> ShortHashProxy<Sz>
 /// assert_eq!(letters.get(&'y'), None);
 /// ```
 #[derive(Clone)]
-#[allow(deprecated)]
-#[deprecated(note = "the crate ordermap has been renamed with no change in \
-              functionality to indexmap; please update your dependencies")]
-pub struct OrderMap<K, V, S = RandomState> {
+pub struct IndexMap<K, V, S = RandomState> {
     core: OrderMapCore<K, V>,
     hash_builder: S,
 }
+
+#[deprecated(note = "OrderMap has been renamed to IndexMap")]
+pub type OrderMap<K, V, S = RandomState> = IndexMap<K, V, S>;
 
 // core of the map that does not depend on S
 #[derive(Clone)]
@@ -302,7 +300,7 @@ enum Inserted<V> {
     }
 }
 
-impl<K, V, S> fmt::Debug for OrderMap<K, V, S>
+impl<K, V, S> fmt::Debug for IndexMap<K, V, S>
     where K: fmt::Debug + Hash + Eq,
           V: fmt::Debug,
           S: BuildHasher,
@@ -358,7 +356,7 @@ macro_rules! probe_loop {
     }
 }
 
-impl<K, V> OrderMap<K, V> {
+impl<K, V> IndexMap<K, V> {
     /// Create a new map. (Does not allocate.)
     pub fn new() -> Self {
         Self::with_capacity(0)
@@ -373,7 +371,7 @@ impl<K, V> OrderMap<K, V> {
     }
 }
 
-impl<K, V, S> OrderMap<K, V, S>
+impl<K, V, S> IndexMap<K, V, S>
 {
     /// Create a new map with capacity for `n` key-value pairs. (Does not
     /// allocate if `n` is zero.)
@@ -383,7 +381,7 @@ impl<K, V, S> OrderMap<K, V, S>
         where S: BuildHasher
     {
         if n == 0 {
-            OrderMap {
+            IndexMap {
                 core: OrderMapCore {
                     mask: 0,
                     indices: Box::new([]),
@@ -394,7 +392,7 @@ impl<K, V, S> OrderMap<K, V, S>
         } else {
             let raw = to_raw_capacity(n);
             let raw_cap = max(raw.next_power_of_two(), 8);
-            OrderMap {
+            IndexMap {
                 core: OrderMapCore {
                     mask: raw_cap.wrapping_sub(1),
                     indices: vec![Pos::none(); raw_cap].into_boxed_slice(),
@@ -637,7 +635,7 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
     }
 }
 
-impl<K, V, S> OrderMap<K, V, S>
+impl<K, V, S> IndexMap<K, V, S>
     where K: Hash + Eq,
           S: BuildHasher,
 {
@@ -948,7 +946,7 @@ impl<K, V, S> OrderMap<K, V, S>
         self.into_iter()
     }
 
-    /// Clears the `OrderMap`, returning all key-value pairs as a drain iterator.
+    /// Clears the `IndexMap`, returning all key-value pairs as a drain iterator.
     /// Keeps the allocated memory for reuse.
     pub fn drain(&mut self, range: RangeFull) -> Drain<K, V> {
         self.core.clear_indices();
@@ -965,7 +963,7 @@ fn key_cmp<K, V>(k1: &K, _v1: &V, k2: &K, _v2: &V) -> Ordering
     Ord::cmp(k1, k2)
 }
 
-impl<K, V, S> OrderMap<K, V, S> {
+impl<K, V, S> IndexMap<K, V, S> {
     /// Get a key-value pair by index
     ///
     /// Valid indices are *0 <= index < self.len()*
@@ -1382,7 +1380,7 @@ impl<K, V> OrderMapCore<K, V> {
 }
 
 /// Find, in the indices, an entry that already exists at a known position
-/// inside self.entries in the OrderMap.
+/// inside self.entries in the IndexMap.
 ///
 /// This is effectively reverse lookup, from the entries into the hash buckets.
 ///
@@ -1556,7 +1554,7 @@ impl<'a, K, V> DoubleEndedIterator for Drain<'a, K, V> {
 }
 
 
-impl<'a, K, V, S> IntoIterator for &'a OrderMap<K, V, S>
+impl<'a, K, V, S> IntoIterator for &'a IndexMap<K, V, S>
     where K: Hash + Eq,
           S: BuildHasher,
 {
@@ -1567,7 +1565,7 @@ impl<'a, K, V, S> IntoIterator for &'a OrderMap<K, V, S>
     }
 }
 
-impl<'a, K, V, S> IntoIterator for &'a mut OrderMap<K, V, S>
+impl<'a, K, V, S> IntoIterator for &'a mut IndexMap<K, V, S>
     where K: Hash + Eq,
           S: BuildHasher,
 {
@@ -1578,7 +1576,7 @@ impl<'a, K, V, S> IntoIterator for &'a mut OrderMap<K, V, S>
     }
 }
 
-impl<K, V, S> IntoIterator for OrderMap<K, V, S>
+impl<K, V, S> IntoIterator for IndexMap<K, V, S>
     where K: Hash + Eq,
           S: BuildHasher,
 {
@@ -1593,7 +1591,7 @@ impl<K, V, S> IntoIterator for OrderMap<K, V, S>
 
 use std::ops::{Index, IndexMut};
 
-impl<'a, K, V, Q: ?Sized, S> Index<&'a Q> for OrderMap<K, V, S>
+impl<'a, K, V, Q: ?Sized, S> Index<&'a Q> for IndexMap<K, V, S>
     where Q: Hash + Equivalent<K>,
           K: Hash + Eq,
           S: BuildHasher,
@@ -1605,7 +1603,7 @@ impl<'a, K, V, Q: ?Sized, S> Index<&'a Q> for OrderMap<K, V, S>
         if let Some(v) = self.get(key) {
             v
         } else {
-            panic!("OrderMap: key not found")
+            panic!("IndexMap: key not found")
         }
     }
 }
@@ -1614,7 +1612,7 @@ impl<'a, K, V, Q: ?Sized, S> Index<&'a Q> for OrderMap<K, V, S>
 /// pairs that are already present.
 ///
 /// You can **not** insert new pairs with index syntax, use `.insert()`.
-impl<'a, K, V, Q: ?Sized, S> IndexMut<&'a Q> for OrderMap<K, V, S>
+impl<'a, K, V, Q: ?Sized, S> IndexMut<&'a Q> for IndexMap<K, V, S>
     where Q: Hash + Equivalent<K>,
           K: Hash + Eq,
           S: BuildHasher,
@@ -1624,16 +1622,16 @@ impl<'a, K, V, Q: ?Sized, S> IndexMut<&'a Q> for OrderMap<K, V, S>
         if let Some(v) = self.get_mut(key) {
             v
         } else {
-            panic!("OrderMap: key not found")
+            panic!("IndexMap: key not found")
         }
     }
 }
 
-impl<K, V, S> FromIterator<(K, V)> for OrderMap<K, V, S>
+impl<K, V, S> FromIterator<(K, V)> for IndexMap<K, V, S>
     where K: Hash + Eq,
           S: BuildHasher + Default,
 {
-    /// Create an `OrderMap` from the sequence of key-value pairs in the
+    /// Create an `IndexMap` from the sequence of key-value pairs in the
     /// iterable.
     ///
     /// `from_iter` uses the same logic as `extend`. See
@@ -1647,7 +1645,7 @@ impl<K, V, S> FromIterator<(K, V)> for OrderMap<K, V, S>
     }
 }
 
-impl<K, V, S> Extend<(K, V)> for OrderMap<K, V, S>
+impl<K, V, S> Extend<(K, V)> for IndexMap<K, V, S>
     where K: Hash + Eq,
           S: BuildHasher,
 {
@@ -1665,7 +1663,7 @@ impl<K, V, S> Extend<(K, V)> for OrderMap<K, V, S>
     }
 }
 
-impl<'a, K, V, S> Extend<(&'a K, &'a V)> for OrderMap<K, V, S>
+impl<'a, K, V, S> Extend<(&'a K, &'a V)> for IndexMap<K, V, S>
     where K: Hash + Eq + Copy,
           V: Copy,
           S: BuildHasher,
@@ -1678,22 +1676,22 @@ impl<'a, K, V, S> Extend<(&'a K, &'a V)> for OrderMap<K, V, S>
     }
 }
 
-impl<K, V, S> Default for OrderMap<K, V, S>
+impl<K, V, S> Default for IndexMap<K, V, S>
     where S: BuildHasher + Default,
 {
-    /// Return an empty `OrderMap`
+    /// Return an empty `IndexMap`
     fn default() -> Self {
         Self::with_capacity_and_hasher(0, S::default())
     }
 }
 
-impl<K, V1, S1, V2, S2> PartialEq<OrderMap<K, V2, S2>> for OrderMap<K, V1, S1>
+impl<K, V1, S1, V2, S2> PartialEq<IndexMap<K, V2, S2>> for IndexMap<K, V1, S1>
     where K: Hash + Eq,
           V1: PartialEq<V2>,
           S1: BuildHasher,
           S2: BuildHasher
 {
-    fn eq(&self, other: &OrderMap<K, V2, S2>) -> bool {
+    fn eq(&self, other: &IndexMap<K, V2, S2>) -> bool {
         if self.len() != other.len() {
             return false;
         }
@@ -1702,7 +1700,7 @@ impl<K, V1, S1, V2, S2> PartialEq<OrderMap<K, V2, S2>> for OrderMap<K, V1, S1>
     }
 }
 
-impl<K, V, S> Eq for OrderMap<K, V, S>
+impl<K, V, S> Eq for IndexMap<K, V, S>
     where K: Eq + Hash,
           V: Eq,
           S: BuildHasher
@@ -1716,7 +1714,7 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         assert_eq!(map.is_empty(), true);
         map.insert(1, ());
         map.insert(1, ());
@@ -1727,7 +1725,7 @@ mod tests {
 
     #[test]
     fn new() {
-        let map = OrderMap::<String, String>::new();
+        let map = IndexMap::<String, String>::new();
         println!("{:?}", map);
         assert_eq!(map.capacity(), 0);
         assert_eq!(map.len(), 0);
@@ -1738,7 +1736,7 @@ mod tests {
     fn insert() {
         let insert = [0, 4, 2, 12, 8, 7, 11, 5];
         let not_present = [1, 3, 6, 9, 10];
-        let mut map = OrderMap::with_capacity(insert.len());
+        let mut map = IndexMap::with_capacity(insert.len());
 
         for (i, &elt) in enumerate(&insert) {
             assert_eq!(map.len(), i);
@@ -1756,7 +1754,7 @@ mod tests {
 
     #[test]
     fn insert_2() {
-        let mut map = OrderMap::with_capacity(16);
+        let mut map = IndexMap::with_capacity(16);
 
         let mut keys = vec![];
         keys.extend(0..16);
@@ -1782,7 +1780,7 @@ mod tests {
     #[test]
     fn insert_order() {
         let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
 
         for &elt in &insert {
             map.insert(elt, ());
@@ -1802,7 +1800,7 @@ mod tests {
     fn grow() {
         let insert = [0, 4, 2, 12, 8, 7, 11];
         let not_present = [1, 3, 6, 9, 10];
-        let mut map = OrderMap::with_capacity(insert.len());
+        let mut map = IndexMap::with_capacity(insert.len());
 
 
         for (i, &elt) in enumerate(&insert) {
@@ -1832,7 +1830,7 @@ mod tests {
     #[test]
     fn remove() {
         let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
 
         for &elt in &insert {
             map.insert(elt, elt);
@@ -1877,7 +1875,7 @@ mod tests {
     #[test]
     fn swap_remove_index() {
         let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
 
         for &elt in &insert {
             map.insert(elt, elt * 2);
@@ -1901,7 +1899,7 @@ mod tests {
 
     #[test]
     fn partial_eq_and_eq() {
-        let mut map_a = OrderMap::new();
+        let mut map_a = IndexMap::new();
         map_a.insert(1, "1");
         map_a.insert(2, "2");
         let mut map_b = map_a.clone();
@@ -1909,14 +1907,14 @@ mod tests {
         map_b.remove(&1);
         assert_ne!(map_a, map_b);
 
-        let map_c: OrderMap<_, String> = map_b.into_iter().map(|(k, v)| (k, v.to_owned())).collect();
+        let map_c: IndexMap<_, String> = map_b.into_iter().map(|(k, v)| (k, v.to_owned())).collect();
         assert_ne!(map_a, map_c);
         assert_ne!(map_c, map_a);
     }
 
     #[test]
     fn extend() {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         map.extend(vec![(&1, &2), (&3, &4)]);
         map.extend(vec![(5, 6)]);
         assert_eq!(map.into_iter().collect::<Vec<_>>(), vec![(1, 2), (3, 4), (5, 6)]);
@@ -1924,7 +1922,7 @@ mod tests {
 
     #[test]
     fn entry() {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         
         map.insert(1, "1");
         map.insert(2, "2");

--- a/src/map.rs
+++ b/src/map.rs
@@ -248,7 +248,7 @@ impl<Sz> ShortHashProxy<Sz>
 /// # Examples
 ///
 /// ```
-/// use ordermap::IndexMap;
+/// use indexmap::IndexMap;
 ///
 /// // count the frequency of each letter in a sentence.
 /// let mut letters = IndexMap::new();
@@ -1865,7 +1865,7 @@ mod tests {
 
     #[test]
     fn remove_to_empty() {
-        let mut map = ordermap! { 0 => 0, 4 => 4, 5 => 5 };
+        let mut map = indexmap! { 0 => 0, 4 => 4, 5 => 5 };
         map.swap_remove(&5).unwrap();
         map.swap_remove(&4).unwrap();
         map.swap_remove(&0).unwrap();

--- a/src/map.rs
+++ b/src/map.rs
@@ -267,6 +267,7 @@ pub struct IndexMap<K, V, S = RandomState> {
     hash_builder: S,
 }
 
+/// Old name; use [`IndexMap`](struct.IndexMap.html) instead.
 #[deprecated(note = "OrderMap has been renamed to IndexMap")]
 pub type OrderMap<K, V, S = RandomState> = IndexMap<K, V, S>;
 

--- a/src/mutable_keys.rs
+++ b/src/mutable_keys.rs
@@ -2,8 +2,7 @@
 use std::hash::Hash;
 use std::hash::BuildHasher;
 
-#[allow(deprecated)]
-use super::{OrderMap, Equivalent};
+use super::{IndexMap, Equivalent};
 
 pub struct PrivateMarker { }
 
@@ -18,7 +17,7 @@ pub struct PrivateMarker { }
 /// This is sound (memory safe) but a logical error hazard (just like
 /// implementing PartialEq, Eq, or Hash incorrectly would be).
 ///
-/// `use` this trait to enable its methods for `OrderMap`.
+/// `use` this trait to enable its methods for `IndexMap`.
 pub trait MutableKeys {
     type Key;
     type Value;
@@ -44,11 +43,10 @@ pub trait MutableKeys {
     fn __private_marker(&self) -> PrivateMarker;
 }
 
-#[allow(deprecated)]
 /// Opt-in mutable access to keys.
 ///
 /// See [`MutableKeys`](trait.MutableKeys.html) for more information.
-impl<K, V, S> MutableKeys for OrderMap<K, V, S>
+impl<K, V, S> MutableKeys for IndexMap<K, V, S>
     where K: Eq + Hash,
           S: BuildHasher,
 {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -8,10 +8,10 @@ use std::fmt::{self, Formatter};
 use std::hash::{BuildHasher, Hash};
 use std::marker::PhantomData;
 
-use OrderMap;
+use IndexMap;
 
 /// Requires crate feature `"serde-1"`
-impl<K, V, S> Serialize for OrderMap<K, V, S>
+impl<K, V, S> Serialize for IndexMap<K, V, S>
     where K: Serialize + Hash + Eq,
           V: Serialize,
           S: BuildHasher
@@ -34,7 +34,7 @@ impl<'de, K, V, S> Visitor<'de> for OrderMapVisitor<K, V, S>
           V: Deserialize<'de>,
           S: Default + BuildHasher
 {
-    type Value = OrderMap<K, V, S>;
+    type Value = IndexMap<K, V, S>;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter, "a map")
@@ -43,7 +43,7 @@ impl<'de, K, V, S> Visitor<'de> for OrderMapVisitor<K, V, S>
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
         where A: MapAccess<'de>
     {
-        let mut values = OrderMap::with_capacity_and_hasher(map.size_hint().unwrap_or(0), S::default());
+        let mut values = IndexMap::with_capacity_and_hasher(map.size_hint().unwrap_or(0), S::default());
 
         while let Some((key, value)) = try!(map.next_entry()) {
             values.insert(key, value);
@@ -54,7 +54,7 @@ impl<'de, K, V, S> Visitor<'de> for OrderMapVisitor<K, V, S>
 }
 
 /// Requires crate feature `"serde-1"`
-impl<'de, K, V, S> Deserialize<'de> for OrderMap<K, V, S>
+impl<'de, K, V, S> Deserialize<'de> for IndexMap<K, V, S>
     where K: Deserialize<'de> + Eq + Hash,
           V: Deserialize<'de>,
           S: Default + BuildHasher
@@ -67,10 +67,10 @@ impl<'de, K, V, S> Deserialize<'de> for OrderMap<K, V, S>
 }
 
 
-use OrderSet;
+use IndexSet;
 
 /// Requires crate feature `"serde-1"`
-impl<T, S> Serialize for OrderSet<T, S>
+impl<T, S> Serialize for IndexSet<T, S>
     where T: Serialize + Hash + Eq,
           S: BuildHasher
 {
@@ -91,7 +91,7 @@ impl<'de, T, S> Visitor<'de> for OrderSetVisitor<T, S>
     where T: Deserialize<'de> + Eq + Hash,
           S: Default + BuildHasher
 {
-    type Value = OrderSet<T, S>;
+    type Value = IndexSet<T, S>;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter, "a set")
@@ -100,7 +100,7 @@ impl<'de, T, S> Visitor<'de> for OrderSetVisitor<T, S>
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
         where A: SeqAccess<'de>
     {
-        let mut values = OrderSet::with_capacity_and_hasher(seq.size_hint().unwrap_or(0), S::default());
+        let mut values = IndexSet::with_capacity_and_hasher(seq.size_hint().unwrap_or(0), S::default());
 
         while let Some(value) = try!(seq.next_element()) {
             values.insert(value);
@@ -111,7 +111,7 @@ impl<'de, T, S> Visitor<'de> for OrderSetVisitor<T, S>
 }
 
 /// Requires crate feature `"serde-1"`
-impl<'de, T, S> Deserialize<'de> for OrderSet<T, S>
+impl<'de, T, S> Deserialize<'de> for IndexSet<T, S>
     where T: Deserialize<'de> + Eq + Hash,
           S: Default + BuildHasher
 {

--- a/src/set.rs
+++ b/src/set.rs
@@ -45,7 +45,7 @@ type Bucket<T> = super::Bucket<T, ()>;
 /// # Examples
 ///
 /// ```
-/// use ordermap::IndexSet;
+/// use indexmap::IndexSet;
 ///
 /// // Collects which letters appear in a sentence.
 /// let letters: IndexSet<_> = "a short treatise on fungi".chars().collect();

--- a/src/set.rs
+++ b/src/set.rs
@@ -60,6 +60,7 @@ pub struct IndexSet<T, S = RandomState> {
     map: IndexMap<T, (), S>,
 }
 
+/// Old name; use [`IndexSet`](struct.IndexSet.html) instead.
 #[deprecated(note = "OrderSet has been renamed to IndexSet")]
 pub type OrderSet<T, S = RandomState> = IndexSet<T, S>;
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,5 +1,4 @@
-//! A hash set implemented using `OrderMap`
-#![allow(deprecated)]
+//! A hash set implemented using `IndexMap`
 
 use std::cmp::Ordering;
 use std::collections::hash_map::RandomState;
@@ -11,7 +10,7 @@ use std::ops::{BitAnd, BitOr, BitXor, Sub};
 use std::slice;
 use std::vec;
 
-use super::{OrderMap, Equivalent};
+use super::{IndexMap, Equivalent};
 
 type Bucket<T> = super::Bucket<T, ()>;
 
@@ -46,10 +45,10 @@ type Bucket<T> = super::Bucket<T, ()>;
 /// # Examples
 ///
 /// ```
-/// use ordermap::OrderSet;
+/// use ordermap::IndexSet;
 ///
 /// // Collects which letters appear in a sentence.
-/// let letters: OrderSet<_> = "a short treatise on fungi".chars().collect();
+/// let letters: IndexSet<_> = "a short treatise on fungi".chars().collect();
 /// 
 /// assert!(letters.contains(&'s'));
 /// assert!(letters.contains(&'t'));
@@ -57,13 +56,14 @@ type Bucket<T> = super::Bucket<T, ()>;
 /// assert!(!letters.contains(&'y'));
 /// ```
 #[derive(Clone)]
-#[deprecated(note = "the crate ordermap has been renamed with no change in \
-              functionality to indexmap; please update your dependencies")]
-pub struct OrderSet<T, S = RandomState> {
-    map: OrderMap<T, (), S>,
+pub struct IndexSet<T, S = RandomState> {
+    map: IndexMap<T, (), S>,
 }
 
-impl<T, S> fmt::Debug for OrderSet<T, S>
+#[deprecated(note = "OrderSet has been renamed to IndexSet")]
+pub type OrderSet<T, S = RandomState> = IndexSet<T, S>;
+
+impl<T, S> fmt::Debug for IndexSet<T, S>
     where T: fmt::Debug + Hash + Eq,
           S: BuildHasher,
 {
@@ -71,16 +71,16 @@ impl<T, S> fmt::Debug for OrderSet<T, S>
         if cfg!(not(feature = "test_debug")) {
             f.debug_set().entries(self.iter()).finish()
         } else {
-            // Let the inner `OrderMap` print all of its details
-            f.debug_struct("OrderSet").field("map", &self.map).finish()
+            // Let the inner `IndexMap` print all of its details
+            f.debug_struct("IndexSet").field("map", &self.map).finish()
         }
     }
 }
 
-impl<T> OrderSet<T> {
+impl<T> IndexSet<T> {
     /// Create a new set. (Does not allocate.)
     pub fn new() -> Self {
-        OrderSet { map: OrderMap::new() }
+        IndexSet { map: IndexMap::new() }
     }
 
     /// Create a new set with capacity for `n` elements.
@@ -88,11 +88,11 @@ impl<T> OrderSet<T> {
     ///
     /// Computes in **O(n)** time.
     pub fn with_capacity(n: usize) -> Self {
-        OrderSet { map: OrderMap::with_capacity(n) }
+        IndexSet { map: IndexMap::with_capacity(n) }
     }
 }
 
-impl<T, S> OrderSet<T, S> {
+impl<T, S> IndexSet<T, S> {
     /// Create a new set with capacity for `n` elements.
     /// (Does not allocate if `n` is zero.)
     ///
@@ -100,7 +100,7 @@ impl<T, S> OrderSet<T, S> {
     pub fn with_capacity_and_hasher(n: usize, hash_builder: S) -> Self
         where S: BuildHasher
     {
-        OrderSet { map: OrderMap::with_capacity_and_hasher(n, hash_builder) }
+        IndexSet { map: IndexMap::with_capacity_and_hasher(n, hash_builder) }
     }
 
     /// Return the number of elements in the set.
@@ -121,7 +121,7 @@ impl<T, S> OrderSet<T, S> {
     pub fn with_hasher(hash_builder: S) -> Self
         where S: BuildHasher
     {
-        OrderSet { map: OrderMap::with_hasher(hash_builder) }
+        IndexSet { map: IndexMap::with_hasher(hash_builder) }
     }
 
     /// Return a reference to the set's `BuildHasher`.
@@ -137,7 +137,7 @@ impl<T, S> OrderSet<T, S> {
     }
 }
 
-impl<T, S> OrderSet<T, S>
+impl<T, S> IndexSet<T, S>
     where T: Hash + Eq,
           S: BuildHasher,
 {
@@ -175,7 +175,7 @@ impl<T, S> OrderSet<T, S>
     /// Return an iterator over the values that are in `self` but not `other`.
     ///
     /// Values are produced in the same order that they appear in `self`.
-    pub fn difference<'a, S2>(&'a self, other: &'a OrderSet<T, S2>) -> Difference<'a, T, S2>
+    pub fn difference<'a, S2>(&'a self, other: &'a IndexSet<T, S2>) -> Difference<'a, T, S2>
         where S2: BuildHasher
     {
         Difference {
@@ -189,7 +189,7 @@ impl<T, S> OrderSet<T, S>
     ///
     /// Values from `self` are produced in their original order, followed by
     /// values from `other` in their original order.
-    pub fn symmetric_difference<'a, S2>(&'a self, other: &'a OrderSet<T, S2>)
+    pub fn symmetric_difference<'a, S2>(&'a self, other: &'a IndexSet<T, S2>)
         -> SymmetricDifference<'a, T, S, S2>
         where S2: BuildHasher
     {
@@ -201,7 +201,7 @@ impl<T, S> OrderSet<T, S>
     /// Return an iterator over the values that are in both `self` and `other`.
     ///
     /// Values are produced in the same order that they appear in `self`.
-    pub fn intersection<'a, S2>(&'a self, other: &'a OrderSet<T, S2>) -> Intersection<'a, T, S2>
+    pub fn intersection<'a, S2>(&'a self, other: &'a IndexSet<T, S2>) -> Intersection<'a, T, S2>
         where S2: BuildHasher
     {
         Intersection {
@@ -214,7 +214,7 @@ impl<T, S> OrderSet<T, S>
     ///
     /// Values from `self` are produced in their original order, followed by
     /// values that are unique to `other` in their original order.
-    pub fn union<'a, S2>(&'a self, other: &'a OrderSet<T, S2>) -> Union<'a, T, S>
+    pub fn union<'a, S2>(&'a self, other: &'a IndexSet<T, S2>) -> Union<'a, T, S>
         where S2: BuildHasher
     {
         Union {
@@ -374,7 +374,7 @@ impl<T, S> OrderSet<T, S>
         }
     }
 
-    /// Clears the `OrderSet`, returning all values as a drain iterator.
+    /// Clears the `IndexSet`, returning all values as a drain iterator.
     /// Keeps the allocated memory for reuse.
     pub fn drain(&mut self, range: RangeFull) -> Drain<T> {
         Drain {
@@ -383,7 +383,7 @@ impl<T, S> OrderSet<T, S>
     }
 }
 
-impl<T, S> OrderSet<T, S> {
+impl<T, S> IndexSet<T, S> {
     /// Get a value by index
     ///
     /// Valid indices are *0 <= index < self.len()*
@@ -463,7 +463,7 @@ impl<'a, T> DoubleEndedIterator for Drain<'a, T> {
     double_ended_iterator_methods!(Bucket::key);
 }
 
-impl<'a, T, S> IntoIterator for &'a OrderSet<T, S>
+impl<'a, T, S> IntoIterator for &'a IndexSet<T, S>
     where T: Hash + Eq,
           S: BuildHasher,
 {
@@ -475,7 +475,7 @@ impl<'a, T, S> IntoIterator for &'a OrderSet<T, S>
     }
 }
 
-impl<T, S> IntoIterator for OrderSet<T, S>
+impl<T, S> IntoIterator for IndexSet<T, S>
     where T: Hash + Eq,
           S: BuildHasher,
 {
@@ -489,17 +489,17 @@ impl<T, S> IntoIterator for OrderSet<T, S>
     }
 }
 
-impl<T, S> FromIterator<T> for OrderSet<T, S>
+impl<T, S> FromIterator<T> for IndexSet<T, S>
     where T: Hash + Eq,
           S: BuildHasher + Default,
 {
     fn from_iter<I: IntoIterator<Item=T>>(iterable: I) -> Self {
         let iter = iterable.into_iter().map(|x| (x, ()));
-        OrderSet { map: OrderMap::from_iter(iter) }
+        IndexSet { map: IndexMap::from_iter(iter) }
     }
 }
 
-impl<T, S> Extend<T> for OrderSet<T, S>
+impl<T, S> Extend<T> for IndexSet<T, S>
     where T: Hash + Eq,
           S: BuildHasher,
 {
@@ -509,7 +509,7 @@ impl<T, S> Extend<T> for OrderSet<T, S>
     }
 }
 
-impl<'a, T, S> Extend<&'a T> for OrderSet<T, S>
+impl<'a, T, S> Extend<&'a T> for IndexSet<T, S>
     where T: Hash + Eq + Copy,
           S: BuildHasher,
 {
@@ -520,37 +520,37 @@ impl<'a, T, S> Extend<&'a T> for OrderSet<T, S>
 }
 
 
-impl<T, S> Default for OrderSet<T, S>
+impl<T, S> Default for IndexSet<T, S>
     where S: BuildHasher + Default,
 {
-    /// Return an empty `OrderSet`
+    /// Return an empty `IndexSet`
     fn default() -> Self {
-        OrderSet { map: OrderMap::default() }
+        IndexSet { map: IndexMap::default() }
     }
 }
 
-impl<T, S1, S2> PartialEq<OrderSet<T, S2>> for OrderSet<T, S1>
+impl<T, S1, S2> PartialEq<IndexSet<T, S2>> for IndexSet<T, S1>
     where T: Hash + Eq,
           S1: BuildHasher,
           S2: BuildHasher
 {
-    fn eq(&self, other: &OrderSet<T, S2>) -> bool {
+    fn eq(&self, other: &IndexSet<T, S2>) -> bool {
         self.len() == other.len() && self.is_subset(other)
     }
 }
 
-impl<T, S> Eq for OrderSet<T, S>
+impl<T, S> Eq for IndexSet<T, S>
     where T: Eq + Hash,
           S: BuildHasher
 {
 }
 
-impl<T, S> OrderSet<T, S>
+impl<T, S> IndexSet<T, S>
     where T: Eq + Hash,
           S: BuildHasher
 {
     /// Returns `true` if `self` has no elements in common with `other`.
-    pub fn is_disjoint<S2>(&self, other: &OrderSet<T, S2>) -> bool
+    pub fn is_disjoint<S2>(&self, other: &IndexSet<T, S2>) -> bool
         where S2: BuildHasher
     {
         if self.len() <= other.len() {
@@ -561,14 +561,14 @@ impl<T, S> OrderSet<T, S>
     }
 
     /// Returns `true` if all elements of `self` are contained in `other`.
-    pub fn is_subset<S2>(&self, other: &OrderSet<T, S2>) -> bool
+    pub fn is_subset<S2>(&self, other: &IndexSet<T, S2>) -> bool
         where S2: BuildHasher
     {
         self.len() <= other.len() && self.iter().all(move |value| other.contains(value))
     }
 
     /// Returns `true` if all elements of `other` are contained in `self`.
-    pub fn is_superset<S2>(&self, other: &OrderSet<T, S2>) -> bool
+    pub fn is_superset<S2>(&self, other: &IndexSet<T, S2>) -> bool
         where S2: BuildHasher
     {
         other.is_subset(self)
@@ -578,7 +578,7 @@ impl<T, S> OrderSet<T, S>
 
 pub struct Difference<'a, T: 'a, S: 'a> {
     iter: Iter<'a, T>,
-    other: &'a OrderSet<T, S>,
+    other: &'a IndexSet<T, S>,
 }
 
 impl<'a, T, S> Iterator for Difference<'a, T, S>
@@ -618,7 +618,7 @@ impl<'a, T, S> DoubleEndedIterator for Difference<'a, T, S>
 
 pub struct Intersection<'a, T: 'a, S: 'a> {
     iter: Iter<'a, T>,
-    other: &'a OrderSet<T, S>,
+    other: &'a IndexSet<T, S>,
 }
 
 impl<'a, T, S> Iterator for Intersection<'a, T, S>
@@ -728,64 +728,64 @@ impl<'a, T, S> DoubleEndedIterator for Union<'a, T, S>
 }
 
 
-impl<'a, 'b, T, S1, S2> BitAnd<&'b OrderSet<T, S2>> for &'a OrderSet<T, S1>
+impl<'a, 'b, T, S1, S2> BitAnd<&'b IndexSet<T, S2>> for &'a IndexSet<T, S1>
     where T: Eq + Hash + Clone,
           S1: BuildHasher + Default,
           S2: BuildHasher,
 {
-    type Output = OrderSet<T, S1>;
+    type Output = IndexSet<T, S1>;
 
     /// Returns the set intersection, cloned into a new set.
     ///
     /// Values are collected in the same order that they appear in `self`.
-    fn bitand(self, other: &'b OrderSet<T, S2>) -> Self::Output {
+    fn bitand(self, other: &'b IndexSet<T, S2>) -> Self::Output {
         self.intersection(other).cloned().collect()
     }
 }
 
-impl<'a, 'b, T, S1, S2> BitOr<&'b OrderSet<T, S2>> for &'a OrderSet<T, S1>
+impl<'a, 'b, T, S1, S2> BitOr<&'b IndexSet<T, S2>> for &'a IndexSet<T, S1>
     where T: Eq + Hash + Clone,
           S1: BuildHasher + Default,
           S2: BuildHasher,
 {
-    type Output = OrderSet<T, S1>;
+    type Output = IndexSet<T, S1>;
 
     /// Returns the set union, cloned into a new set.
     ///
     /// Values from `self` are collected in their original order, followed by
     /// values that are unique to `other` in their original order.
-    fn bitor(self, other: &'b OrderSet<T, S2>) -> Self::Output {
+    fn bitor(self, other: &'b IndexSet<T, S2>) -> Self::Output {
         self.union(other).cloned().collect()
     }
 }
 
-impl<'a, 'b, T, S1, S2> BitXor<&'b OrderSet<T, S2>> for &'a OrderSet<T, S1>
+impl<'a, 'b, T, S1, S2> BitXor<&'b IndexSet<T, S2>> for &'a IndexSet<T, S1>
     where T: Eq + Hash + Clone,
           S1: BuildHasher + Default,
           S2: BuildHasher,
 {
-    type Output = OrderSet<T, S1>;
+    type Output = IndexSet<T, S1>;
 
     /// Returns the set symmetric-difference, cloned into a new set.
     ///
     /// Values from `self` are collected in their original order, followed by
     /// values from `other` in their original order.
-    fn bitxor(self, other: &'b OrderSet<T, S2>) -> Self::Output {
+    fn bitxor(self, other: &'b IndexSet<T, S2>) -> Self::Output {
         self.symmetric_difference(other).cloned().collect()
     }
 }
 
-impl<'a, 'b, T, S1, S2> Sub<&'b OrderSet<T, S2>> for &'a OrderSet<T, S1>
+impl<'a, 'b, T, S1, S2> Sub<&'b IndexSet<T, S2>> for &'a IndexSet<T, S1>
     where T: Eq + Hash + Clone,
           S1: BuildHasher + Default,
           S2: BuildHasher,
 {
-    type Output = OrderSet<T, S1>;
+    type Output = IndexSet<T, S1>;
 
     /// Returns the set difference, cloned into a new set.
     ///
     /// Values are collected in the same order that they appear in `self`.
-    fn sub(self, other: &'b OrderSet<T, S2>) -> Self::Output {
+    fn sub(self, other: &'b IndexSet<T, S2>) -> Self::Output {
         self.difference(other).cloned().collect()
     }
 }
@@ -798,7 +798,7 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let mut set = OrderSet::new();
+        let mut set = IndexSet::new();
         assert_eq!(set.is_empty(), true);
         set.insert(1);
         set.insert(1);
@@ -809,7 +809,7 @@ mod tests {
 
     #[test]
     fn new() {
-        let set = OrderSet::<String>::new();
+        let set = IndexSet::<String>::new();
         println!("{:?}", set);
         assert_eq!(set.capacity(), 0);
         assert_eq!(set.len(), 0);
@@ -820,7 +820,7 @@ mod tests {
     fn insert() {
         let insert = [0, 4, 2, 12, 8, 7, 11, 5];
         let not_present = [1, 3, 6, 9, 10];
-        let mut set = OrderSet::with_capacity(insert.len());
+        let mut set = IndexSet::with_capacity(insert.len());
 
         for (i, &elt) in enumerate(&insert) {
             assert_eq!(set.len(), i);
@@ -837,7 +837,7 @@ mod tests {
 
     #[test]
     fn insert_2() {
-        let mut set = OrderSet::with_capacity(16);
+        let mut set = IndexSet::with_capacity(16);
 
         let mut values = vec![];
         values.extend(0..16);
@@ -863,7 +863,7 @@ mod tests {
     #[test]
     fn insert_dup() {
         let mut elements = vec![0, 2, 4, 6, 8];
-        let mut set: OrderSet<u8> = elements.drain(..).collect();
+        let mut set: IndexSet<u8> = elements.drain(..).collect();
         {
             let (i, v) = set.get_full(&0).unwrap();
             assert_eq!(set.len(), 5);
@@ -883,7 +883,7 @@ mod tests {
     #[test]
     fn insert_order() {
         let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
-        let mut set = OrderSet::new();
+        let mut set = IndexSet::new();
 
         for &elt in &insert {
             set.insert(elt);
@@ -903,7 +903,7 @@ mod tests {
     fn grow() {
         let insert = [0, 4, 2, 12, 8, 7, 11];
         let not_present = [1, 3, 6, 9, 10];
-        let mut set = OrderSet::with_capacity(insert.len());
+        let mut set = IndexSet::with_capacity(insert.len());
 
 
         for (i, &elt) in enumerate(&insert) {
@@ -932,7 +932,7 @@ mod tests {
     #[test]
     fn remove() {
         let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
-        let mut set = OrderSet::new();
+        let mut set = IndexSet::new();
 
         for &elt in &insert {
             set.insert(elt);
@@ -968,7 +968,7 @@ mod tests {
     #[test]
     fn swap_remove_index() {
         let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
-        let mut set = OrderSet::new();
+        let mut set = IndexSet::new();
 
         for &elt in &insert {
             set.insert(elt);
@@ -992,7 +992,7 @@ mod tests {
 
     #[test]
     fn partial_eq_and_eq() {
-        let mut set_a = OrderSet::new();
+        let mut set_a = IndexSet::new();
         set_a.insert(1);
         set_a.insert(2);
         let mut set_b = set_a.clone();
@@ -1000,14 +1000,14 @@ mod tests {
         set_b.remove(&1);
         assert_ne!(set_a, set_b);
 
-        let set_c: OrderSet<_> = set_b.into_iter().collect();
+        let set_c: IndexSet<_> = set_b.into_iter().collect();
         assert_ne!(set_a, set_c);
         assert_ne!(set_c, set_a);
     }
 
     #[test]
     fn extend() {
-        let mut set = OrderSet::new();
+        let mut set = IndexSet::new();
         set.extend(vec![&1, &2, &3, &4]);
         set.extend(vec![5, 6]);
         assert_eq!(set.into_iter().collect::<Vec<_>>(), vec![1, 2, 3, 4, 5, 6]);
@@ -1015,10 +1015,10 @@ mod tests {
 
     #[test]
     fn comparisons() {
-        let set_a: OrderSet<_> = (0..3).collect();
-        let set_b: OrderSet<_> = (3..6).collect();
-        let set_c: OrderSet<_> = (0..6).collect();
-        let set_d: OrderSet<_> = (3..9).collect();
+        let set_a: IndexSet<_> = (0..3).collect();
+        let set_b: IndexSet<_> = (3..6).collect();
+        let set_c: IndexSet<_> = (0..6).collect();
+        let set_d: IndexSet<_> = (3..9).collect();
 
         assert!(!set_a.is_disjoint(&set_a));
         assert!(set_a.is_subset(&set_a));
@@ -1057,10 +1057,10 @@ mod tests {
             assert!(iter1.cloned().eq(iter2));
         }
 
-        let set_a: OrderSet<_> = (0..3).collect();
-        let set_b: OrderSet<_> = (3..6).collect();
-        let set_c: OrderSet<_> = (0..6).collect();
-        let set_d: OrderSet<_> = (3..9).rev().collect();
+        let set_a: IndexSet<_> = (0..3).collect();
+        let set_b: IndexSet<_> = (3..6).collect();
+        let set_c: IndexSet<_> = (0..6).collect();
+        let set_d: IndexSet<_> = (3..9).rev().collect();
 
         check(set_a.difference(&set_a), empty());
         check(set_a.symmetric_difference(&set_a), empty());
@@ -1097,11 +1097,11 @@ mod tests {
 
     #[test]
     fn ops() {
-        let empty = OrderSet::<i32>::new();
-        let set_a: OrderSet<_> = (0..3).collect();
-        let set_b: OrderSet<_> = (3..6).collect();
-        let set_c: OrderSet<_> = (0..6).collect();
-        let set_d: OrderSet<_> = (3..9).rev().collect();
+        let empty = IndexSet::<i32>::new();
+        let set_a: IndexSet<_> = (0..3).collect();
+        let set_b: IndexSet<_> = (3..6).collect();
+        let set_c: IndexSet<_> = (0..6).collect();
+        let set_d: IndexSet<_> = (3..9).rev().collect();
 
         assert_eq!(&set_a & &set_a, set_a);
         assert_eq!(&set_a | &set_a, set_a);

--- a/tests/equivalent_trait.rs
+++ b/tests/equivalent_trait.rs
@@ -1,7 +1,7 @@
 
-#[macro_use] extern crate ordermap;
+#[macro_use] extern crate indexmap;
 
-use ordermap::Equivalent;
+use indexmap::Equivalent;
 
 use std::hash::Hash;
 
@@ -32,7 +32,7 @@ impl<A, B, X> Equivalent<X> for Pair<A, B>
 #[test]
 fn test_lookup() {
     let s = String::from;
-    let map = ordermap! {
+    let map = indexmap! {
         (s("a"), s("b")) => 1,
         (s("a"), s("x")) => 2,
     };
@@ -44,7 +44,7 @@ fn test_lookup() {
 #[test]
 fn test_string_str() {
     let s = String::from;
-    let mut map = ordermap! {
+    let mut map = indexmap! {
         s("a") => 1, s("b") => 2,
         s("x") => 3, s("y") => 4,
     };

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1,12 +1,12 @@
 
-extern crate ordermap;
+extern crate indexmap;
 extern crate itertools;
 #[macro_use]
 extern crate quickcheck;
 
 extern crate fnv;
 
-use ordermap::IndexMap;
+use indexmap::IndexMap;
 use itertools::Itertools;
 
 use quickcheck::Arbitrary;
@@ -26,7 +26,7 @@ use std::ops::Deref;
 use std::cmp::min;
 
 
-use ordermap::map::Entry as OEntry;
+use indexmap::map::Entry as OEntry;
 use std::collections::hash_map::Entry as HEntry;
 
 
@@ -37,7 +37,7 @@ fn set<'a, T: 'a, I>(iter: I) -> HashSet<T>
     iter.into_iter().cloned().collect()
 }
 
-fn ordermap<'a, T: 'a, I>(iter: I) -> IndexMap<T, ()>
+fn indexmap<'a, T: 'a, I>(iter: I) -> IndexMap<T, ()>
     where I: IntoIterator<Item=&'a T>,
           T: Copy + Hash + Eq,
 {
@@ -257,9 +257,9 @@ quickcheck! {
     }
 
     fn retain_ordered(keys: Large<Vec<i8>>, remove: Large<Vec<i8>>) -> () {
-        let mut map = ordermap(keys.iter());
+        let mut map = indexmap(keys.iter());
         let initial_map = map.clone(); // deduplicated in-order input
-        let remove_map = ordermap(remove.iter());
+        let remove_map = indexmap(remove.iter());
         let keys_s = set(keys.iter());
         let remove_s = set(remove.iter());
         let answer = &keys_s - &remove_s;

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -6,7 +6,7 @@ extern crate quickcheck;
 
 extern crate fnv;
 
-use ordermap::OrderMap;
+use ordermap::IndexMap;
 use itertools::Itertools;
 
 use quickcheck::Arbitrary;
@@ -15,7 +15,7 @@ use quickcheck::Gen;
 use fnv::FnvHasher;
 use std::hash::{BuildHasher, BuildHasherDefault};
 type FnvBuilder = BuildHasherDefault<FnvHasher>;
-type OrderMapFnv<K, V> = OrderMap<K, V, FnvBuilder>;
+type OrderMapFnv<K, V> = IndexMap<K, V, FnvBuilder>;
 
 use std::collections::HashSet;
 use std::collections::HashMap;
@@ -37,16 +37,16 @@ fn set<'a, T: 'a, I>(iter: I) -> HashSet<T>
     iter.into_iter().cloned().collect()
 }
 
-fn ordermap<'a, T: 'a, I>(iter: I) -> OrderMap<T, ()>
+fn ordermap<'a, T: 'a, I>(iter: I) -> IndexMap<T, ()>
     where I: IntoIterator<Item=&'a T>,
           T: Copy + Hash + Eq,
 {
-    OrderMap::from_iter(iter.into_iter().cloned().map(|k| (k, ())))
+    IndexMap::from_iter(iter.into_iter().cloned().map(|k| (k, ())))
 }
 
 quickcheck! {
     fn contains(insert: Vec<u32>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         for &key in &insert {
             map.insert(key, ());
         }
@@ -54,7 +54,7 @@ quickcheck! {
     }
 
     fn contains_not(insert: Vec<u8>, not: Vec<u8>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         for &key in &insert {
             map.insert(key, ());
         }
@@ -63,7 +63,7 @@ quickcheck! {
     }
 
     fn insert_remove(insert: Vec<u8>, remove: Vec<u8>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         for &key in &insert {
             map.insert(key, ());
         }
@@ -76,7 +76,7 @@ quickcheck! {
     }
 
     fn insertion_order(insert: Vec<u32>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         for &key in &insert {
             map.insert(key, ());
         }
@@ -85,7 +85,7 @@ quickcheck! {
     }
 
     fn pop(insert: Vec<u8>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         for &key in &insert {
             map.insert(key, ());
         }
@@ -100,13 +100,13 @@ quickcheck! {
     }
 
     fn with_cap(cap: usize) -> bool {
-        let map: OrderMap<u8, u8> = OrderMap::with_capacity(cap);
+        let map: IndexMap<u8, u8> = IndexMap::with_capacity(cap);
         println!("wish: {}, got: {} (diff: {})", cap, map.capacity(), map.capacity() as isize - cap as isize);
         map.capacity() >= cap
     }
 
     fn drain(insert: Vec<u8>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         for &key in &insert {
             map.insert(key, ());
         }
@@ -142,7 +142,7 @@ impl<K, V> Arbitrary for Op<K, V>
     }
 }
 
-fn do_ops<K, V, S>(ops: &[Op<K, V>], a: &mut OrderMap<K, V, S>, b: &mut HashMap<K, V>)
+fn do_ops<K, V, S>(ops: &[Op<K, V>], a: &mut IndexMap<K, V, S>, b: &mut HashMap<K, V>)
     where K: Hash + Eq + Clone,
           V: Clone,
           S: BuildHasher,
@@ -176,7 +176,7 @@ fn do_ops<K, V, S>(ops: &[Op<K, V>], a: &mut OrderMap<K, V, S>, b: &mut HashMap<
     }
 }
 
-fn assert_maps_equivalent<K, V>(a: &OrderMap<K, V>, b: &HashMap<K, V>) -> bool
+fn assert_maps_equivalent<K, V>(a: &IndexMap<K, V>, b: &HashMap<K, V>) -> bool
     where K: Hash + Eq + Debug,
           V: Eq + Debug,
 {
@@ -196,24 +196,24 @@ fn assert_maps_equivalent<K, V>(a: &OrderMap<K, V>, b: &HashMap<K, V>) -> bool
 
 quickcheck! {
     fn operations_i8(ops: Large<Vec<Op<i8, i8>>>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         let mut reference = HashMap::new();
         do_ops(&ops, &mut map, &mut reference);
         assert_maps_equivalent(&map, &reference)
     }
 
     fn operations_string(ops: Vec<Op<Alpha, i8>>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         let mut reference = HashMap::new();
         do_ops(&ops, &mut map, &mut reference);
         assert_maps_equivalent(&map, &reference)
     }
 
     fn keys_values(ops: Large<Vec<Op<i8, i8>>>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         let mut reference = HashMap::new();
         do_ops(&ops, &mut map, &mut reference);
-        let mut visit = OrderMap::new();
+        let mut visit = IndexMap::new();
         for (k, v) in map.keys().zip(map.values()) {
             assert_eq!(&map[k], v);
             assert!(!visit.contains_key(k));
@@ -224,10 +224,10 @@ quickcheck! {
     }
 
     fn keys_values_mut(ops: Large<Vec<Op<i8, i8>>>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         let mut reference = HashMap::new();
         do_ops(&ops, &mut map, &mut reference);
-        let mut visit = OrderMap::new();
+        let mut visit = IndexMap::new();
         let keys = Vec::from_iter(map.keys().cloned());
         for (k, v) in keys.iter().zip(map.values_mut()) {
             assert_eq!(&reference[k], v);
@@ -239,7 +239,7 @@ quickcheck! {
     }
 
     fn equality(ops1: Vec<Op<i8, i8>>, removes: Vec<usize>) -> bool {
-        let mut map = OrderMap::new();
+        let mut map = IndexMap::new();
         let mut reference = HashMap::new();
         do_ops(&ops1, &mut map, &mut reference);
         let mut ops2 = ops1.clone();
@@ -275,11 +275,11 @@ quickcheck! {
     }
 
     fn sort_1(keyvals: Large<Vec<(i8, i8)>>) -> () {
-        let mut map: OrderMap<_, _> = OrderMap::from_iter(keyvals.to_vec());
+        let mut map: IndexMap<_, _> = IndexMap::from_iter(keyvals.to_vec());
         let mut answer = keyvals.0;
         answer.sort_by_key(|t| t.0);
 
-        // reverse dedup: Because OrderMap::from_iter keeps the last value for
+        // reverse dedup: Because IndexMap::from_iter keeps the last value for
         // identical keys
         answer.reverse();
         answer.dedup_by_key(|t| t.0);
@@ -300,7 +300,7 @@ quickcheck! {
     }
 
     fn sort_2(keyvals: Large<Vec<(i8, i8)>>) -> () {
-        let mut map: OrderMap<_, _> = OrderMap::from_iter(keyvals.to_vec());
+        let mut map: IndexMap<_, _> = IndexMap::from_iter(keyvals.to_vec());
         map.sort_by(|_, v1, _, v2| Ord::cmp(v1, v2));
         assert_sorted_by_key(map, |t| t.1);
     }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "serde-1")]
 
 #[macro_use]
-extern crate ordermap;
+extern crate indexmap;
 extern crate serde_test;
 extern crate fnv;
 
@@ -9,7 +9,7 @@ use serde_test::{Token, assert_tokens};
 
 #[test]
 fn test_serde() {
-    let map = ordermap! { 1 => 2, 3 => 4 };
+    let map = indexmap! { 1 => 2, 3 => 4 };
     assert_tokens(&map,
                   &[Token::Map { len: Some(2) },
                     Token::I32(1),
@@ -21,7 +21,7 @@ fn test_serde() {
 
 #[test]
 fn test_serde_set() {
-    let set = orderset! { 1, 2, 3, 4 };
+    let set = indexset! { 1, 2, 3, 4 };
     assert_tokens(&set,
                   &[Token::Seq { len: Some(4) },
                     Token::I32(1),
@@ -33,7 +33,7 @@ fn test_serde_set() {
 
 #[test]
 fn test_serde_fnv_hasher() {
-    let mut map: ::ordermap::IndexMap<i32, i32, ::fnv::FnvBuildHasher> = Default::default();
+    let mut map: ::indexmap::IndexMap<i32, i32, ::fnv::FnvBuildHasher> = Default::default();
     map.insert(1, 2);
     map.insert(3, 4);
     assert_tokens(&map,
@@ -47,7 +47,7 @@ fn test_serde_fnv_hasher() {
 
 #[test]
 fn test_serde_map_fnv_hasher() {
-    let mut set: ::ordermap::IndexSet<i32, ::fnv::FnvBuildHasher> = Default::default();
+    let mut set: ::indexmap::IndexSet<i32, ::fnv::FnvBuildHasher> = Default::default();
     set.extend(1..5);
     assert_tokens(&set,
                   &[Token::Seq { len: Some(4) },

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -33,7 +33,7 @@ fn test_serde_set() {
 
 #[test]
 fn test_serde_fnv_hasher() {
-    let mut map: ::ordermap::OrderMap<i32, i32, ::fnv::FnvBuildHasher> = Default::default();
+    let mut map: ::ordermap::IndexMap<i32, i32, ::fnv::FnvBuildHasher> = Default::default();
     map.insert(1, 2);
     map.insert(3, 4);
     assert_tokens(&map,
@@ -47,7 +47,7 @@ fn test_serde_fnv_hasher() {
 
 #[test]
 fn test_serde_map_fnv_hasher() {
-    let mut set: ::ordermap::OrderSet<i32, ::fnv::FnvBuildHasher> = Default::default();
+    let mut set: ::ordermap::IndexSet<i32, ::fnv::FnvBuildHasher> = Default::default();
     set.extend(1..5);
     assert_tokens(&set,
                   &[Token::Seq { len: Some(4) },

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,12 +1,12 @@
 
 #[macro_use]
-extern crate ordermap;
+extern crate indexmap;
 extern crate itertools;
 
 
 #[test]
 fn test_sort() {
-    let m = ordermap! {
+    let m = indexmap! {
         1 => 2,
         7 => 1,
         2 => 2,
@@ -20,7 +20,7 @@ fn test_sort() {
 
 #[test]
 fn test_sort_set() {
-    let s = orderset! {
+    let s = indexset! {
         1,
         7,
         2,


### PR DESCRIPTION
- `OrderMap` becomes `IndexMap` with no change in functionality
- Releasing version 1.0 of the crate becomes possible shortly after the rename
- This is the big rename; see discussion and rationale in issue #14

Plan:

1. Release ordermap 0.4.1 with a deprecation message pointing to indexmap; in PR #64
2. Release indexmap 0.4.1 with the rename (and deprecated type aliases in place for OrderMap/Set) (this PR)
3. Release indexmap 1.0 with deprecated items removed. (later)

Fixes #14 